### PR TITLE
Cmake build system improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,43 +52,22 @@ option(USE_LLVM "Enable LLVM backend" OFF) # Example option
 
 if(USE_LLVM)
     # Attempt to find LLVM (adjust paths/version as needed)
-    find_package(LLVM REQUIRED CONFIG) # Or adjust version/components
+    find_package(LLVM CONFIG) # Make it non-REQUIRED, handle LLVM_FOUND explicitly
 
     if(LLVM_FOUND)
         message(STATUS "LLVM Found: ${LLVM_PACKAGE_VERSION}")
         message(STATUS "LLVM Include Dirs: ${LLVM_INCLUDE_DIRS}")
         message(STATUS "LLVM Library Dirs: ${LLVM_LIBRARY_DIRS}")
 
-        # Add LLVM source file
-        target_sources(baa PRIVATE src/codegen/llvm_codegen.c)
-
-        # Add LLVM include directories
-        target_include_directories(baa PRIVATE ${LLVM_INCLUDE_DIRS})
-
-        # Add LLVM compile definitions
-        target_compile_definitions(baa PRIVATE LLVM_AVAILABLE=1)
-
-        # Link LLVM libraries
-        # list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}") # Usually handled by find_package
-        # include(AddLLVM) # Usually handled by find_package
-        llvm_map_components_to_libnames(llvm_libs
-            core support irreader analysis target mcjit native executionengine
-            # Add other necessary components
-        )
-        message(STATUS "Linking LLVM Libraries: ${llvm_libs}")
-        target_link_libraries(baa PRIVATE ${llvm_libs})
-
+    # LLVM is found, baa_codegen will use it.
+    # The LLVM_AVAILABLE definition will be set for baa_codegen in its CMakeLists.txt
     else()
         message(WARNING "USE_LLVM is ON but LLVM was not found. Using stub backend.")
-        target_sources(baa PRIVATE src/codegen/llvm_stub.c)
-        target_compile_definitions(baa PRIVATE LLVM_AVAILABLE=0)
+        # LLVM_FOUND will be false, baa_codegen will use stub.
     endif()
 else()
     message(STATUS "LLVM backend disabled. Using stub backend.")
-    # Add stub source file
-    target_sources(baa PRIVATE src/codegen/llvm_stub.c)
-    # Add compile definition
-    target_compile_definitions(baa PRIVATE LLVM_AVAILABLE=0)
+    # LLVM_FOUND will be false (as find_package wasn't called), baa_codegen will use stub.
 endif()
 
 # --- Standalone Preprocessor Tester ---

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,20 +8,17 @@ project(baa
 # إعداد معيار لغة C
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
-
-# Option to skip parser compilation for development (No longer directly applicable this way)
-# option(SKIP_PARSER "Skip compiling the parser components" OFF)
-add_compile_definitions(UNICODE _UNICODE _CRT_SECURE_NO_WARNINGS)
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /IGNORE:4006 /IGNORE:4099") # Ignore certain linker warnings if needed
 
-# إضافة مجلد التضمين الرئيسي
-include_directories(${CMAKE_SOURCE_DIR}/include)
+add_subdirectory(src)
 
 # --- البرنامج الرئيسي ---
 add_executable(baa
     src/main.c
     src/compiler.c
 )
+
+
 
 # Link component libraries to the main executable
 target_link_libraries(baa PRIVATE

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 
 # Option to skip parser compilation for development (No longer directly applicable this way)
 # option(SKIP_PARSER "Skip compiling the parser components" OFF)
-
+add_compile_definitions(UNICODE _UNICODE _CRT_SECURE_NO_WARNINGS)
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /IGNORE:4006 /IGNORE:4099") # Ignore certain linker warnings if needed
 
 # إضافة مجلد التضمين الرئيسي
@@ -110,6 +110,12 @@ target_include_directories(baa_preprocessor_tester
         ${CMAKE_SOURCE_DIR}/src/preprocessor # For preprocessor_internal.h
 )
 
+target_compile_definitions(baa_preprocessor_tester PRIVATE
+    UNICODE
+    _UNICODE
+    _CRT_SECURE_NO_WARNINGS
+)
+
 # --- Standalone Lexer Tester ---
 add_executable(baa_lexer_tester
     tools/baa_lexer_tester.c
@@ -126,6 +132,12 @@ target_include_directories(baa_lexer_tester
     PRIVATE
         ${CMAKE_SOURCE_DIR}/include  # For baa/lexer/lexer.h and baa/utils/*.h
         ${CMAKE_SOURCE_DIR}/src/lexer # For lexer_internal.h if needed by included lexer files
+)
+
+target_compile_definitions(baa_lexer_tester PRIVATE
+    UNICODE
+    _UNICODE
+    _CRT_SECURE_NO_WARNINGS
 )
 
 # تفعيل الاختبارات (معطل مؤقتاً)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.20)
 project(baa
-    VERSION 0.1.12.0
+    VERSION 0.1.17.0
     DESCRIPTION "لغة باء - The Baa Programming Language"
     LANGUAGES C
 )
@@ -12,7 +12,6 @@ set(CMAKE_C_STANDARD_REQUIRED ON)
 # Option to skip parser compilation for development (No longer directly applicable this way)
 # option(SKIP_PARSER "Skip compiling the parser components" OFF)
 
-add_definitions(-DUNICODE -D_UNICODE -D_CRT_SECURE_NO_WARNINGS)
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /IGNORE:4006 /IGNORE:4099") # Ignore certain linker warnings if needed
 
 # إضافة مجلد التضمين الرئيسي
@@ -20,50 +19,31 @@ include_directories(${CMAKE_SOURCE_DIR}/include)
 
 # --- البرنامج الرئيسي ---
 add_executable(baa
-    # Core executable files
     src/main.c
     src/compiler.c
-
-    # Utility files
-    src/utils/utils.c
-
-    # Type system files
-    src/types/types.c
-
-    # Operator files
-    src/operators/operators.c
-
-    # Lexer files
-    src/lexer/lexer.c
-    src/lexer/number_parser.c
-    src/lexer/lexer_char_utils.c
-    src/lexer/token_scanners.c   # Added token scanners source
-
-    # Preprocessor files
-    src/preprocessor/preprocessor.c
-    src/preprocessor/preprocessor_utils.c
-    src/preprocessor/preprocessor_macros.c
-    src/preprocessor/preprocessor_expansion.c
-    src/preprocessor/preprocessor_conditionals.c
-    src/preprocessor/preprocessor_expr_eval.c
-    src/preprocessor/preprocessor_core.c
-    src/preprocessor/preprocessor_directives.c
-    src/preprocessor/preprocessor_line_processing.c
-
-    # Analysis files
-    src/analysis/flow_analysis.c
-    src/analysis/flow_errors.c
-
-    # Codegen core file (always needed)
-    src/codegen/codegen.c
 )
 
-# Include directories for the executable
-target_include_directories(baa
-    PRIVATE
-        ${CMAKE_SOURCE_DIR}/include
-        ${CMAKE_SOURCE_DIR}/src       # Allow includes like "lexer/lexer_char_utils.h" or relative from within src
-        # ${CMAKE_SOURCE_DIR}/src/preprocessor # Already covered by ../src
+# Link component libraries to the main executable
+target_link_libraries(baa PRIVATE
+    baa_utils
+    baa_types
+    baa_operators
+    baa_lexer
+    baa_preprocessor
+    baa_flow_analysis # This library name is defined in src/analysis/CMakeLists.txt
+    baa_codegen
+)
+
+# Include directories and compile definitions for the 'baa' executable
+target_include_directories(baa PRIVATE
+    ${CMAKE_SOURCE_DIR}/include
+    ${CMAKE_SOURCE_DIR}/src       # Allow includes like "lexer/lexer_char_utils.h" or relative from within src
+)
+
+target_compile_definitions(baa PRIVATE
+    UNICODE
+    _UNICODE
+    _CRT_SECURE_NO_WARNINGS
 )
 
 # --- Conditional LLVM Handling ---
@@ -115,47 +95,30 @@ endif()
 # --- Standalone Preprocessor Tester ---
 add_executable(baa_preprocessor_tester
     tools/baa_preprocessor_tester.c
-
-    # Preprocessor files (needed by the tester)
-    src/preprocessor/preprocessor.c
-    src/preprocessor/preprocessor_utils.c
-    src/preprocessor/preprocessor_macros.c
-    src/preprocessor/preprocessor_expansion.c
-    src/preprocessor/preprocessor_conditionals.c
-    src/preprocessor/preprocessor_expr_eval.c
-    src/preprocessor/preprocessor_core.c
-    src/preprocessor/preprocessor_directives.c
-    src/preprocessor/preprocessor_line_processing.c
-
-    # Utility files (needed by the preprocessor)
-    src/utils/utils.c
 )
 
-# Include directories for the tester
+# Link dependencies for the preprocessor tester
+target_link_libraries(baa_preprocessor_tester PRIVATE
+    baa_preprocessor
+    baa_utils
+)
+
+# Include directories for the preprocessor tester
 target_include_directories(baa_preprocessor_tester
     PRIVATE
         ${CMAKE_SOURCE_DIR}/include       # For baa/preprocessor/preprocessor.h
         ${CMAKE_SOURCE_DIR}/src/preprocessor # For preprocessor_internal.h
 )
 
-# Set output directory for the tester executable (optional, but good practice)
-set_target_properties(baa_preprocessor_tester PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-)
-
 # --- Standalone Lexer Tester ---
 add_executable(baa_lexer_tester
     tools/baa_lexer_tester.c
+)
 
-    # Lexer files (needed by the tester)
-    src/lexer/lexer.c
-    src/lexer/number_parser.c
-    src/lexer/lexer_char_utils.c
-    src/lexer/token_scanners.c
-
-    # Utility files (needed by the lexer and tester)
-    src/utils/utils.c
-    # src/utils/errors.c # If errors.c exists and is needed
+# Link dependencies for the lexer tester
+target_link_libraries(baa_lexer_tester PRIVATE
+    baa_lexer
+    baa_utils
 )
 
 # Include directories for the lexer tester
@@ -164,12 +127,6 @@ target_include_directories(baa_lexer_tester
         ${CMAKE_SOURCE_DIR}/include  # For baa/lexer/lexer.h and baa/utils/*.h
         ${CMAKE_SOURCE_DIR}/src/lexer # For lexer_internal.h if needed by included lexer files
 )
-
-# Set output directory for the lexer tester executable
-set_target_properties(baa_lexer_tester PROPERTIES
-    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
-)
-
 
 # تفعيل الاختبارات (معطل مؤقتاً)
 # enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,23 @@
 cmake_minimum_required(VERSION 3.20)
+if(POLICY CMP0074)
+  cmake_policy(SET CMP0074 NEW) # INTERFACE_LINK_LIBRARIES defines the link interface
+endif()
+if(POLICY CMP0067)
+  cmake_policy(SET CMP0067 NEW) # Honor visibility properties for target_compile_definitions
+endif()
+if(POLICY CMP0042)
+  cmake_policy(SET CMP0042 NEW) # MACOSX_RPATH is enabled by default
+endif()
+# Add other policies as you discover needs, e.g., CMP0077 for overriding exported targets.
 project(baa
     VERSION 0.1.17.0
     DESCRIPTION "لغة باء - The Baa Programming Language"
     LANGUAGES C
 )
+
+if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
+    message(FATAL_ERROR "In-source builds are not allowed. Please create a separate build directory (e.g., mkdir build && cd build) and run CMake from there.")
+endif()
 
 # إعداد معيار لغة C
 set(CMAKE_C_STANDARD 11)
@@ -15,22 +29,10 @@ add_subdirectory(src)
 # --- البرنامج الرئيسي ---
 add_executable(baa
     src/main.c
-    src/compiler.c
 )
-
-
 
 # Link component libraries to the main executable
-target_link_libraries(baa PRIVATE
-    baa_utils
-    baa_types
-    baa_operators
-    baa_lexer
-    baa_preprocessor
-    baa_flow_analysis # This library name is defined in src/analysis/CMakeLists.txt
-    baa_codegen
-)
-
+target_link_libraries(baa PRIVATE baa_compiler_lib) # main.c links only the compiler library
 # Include directories and compile definitions for the 'baa' executable
 target_include_directories(baa PRIVATE
     ${CMAKE_SOURCE_DIR}/include

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 cmake_minimum_required(VERSION 3.20)
+
 if(POLICY CMP0074)
   cmake_policy(SET CMP0074 NEW) # INTERFACE_LINK_LIBRARIES defines the link interface
 endif()
@@ -9,11 +10,15 @@ if(POLICY CMP0042)
   cmake_policy(SET CMP0042 NEW) # MACOSX_RPATH is enabled by default
 endif()
 # Add other policies as you discover needs, e.g., CMP0077 for overriding exported targets.
+
 project(baa
     VERSION 0.1.17.0
     DESCRIPTION "لغة باء - The Baa Programming Language"
     LANGUAGES C
 )
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
+include(BaaCompilerSettings)
 
 if(${CMAKE_SOURCE_DIR} STREQUAL ${CMAKE_BINARY_DIR})
     message(FATAL_ERROR "In-source builds are not allowed. Please create a separate build directory (e.g., mkdir build && cd build) and run CMake from there.")
@@ -32,17 +37,11 @@ add_executable(baa
 )
 
 # Link component libraries to the main executable
-target_link_libraries(baa PRIVATE baa_compiler_lib) # main.c links only the compiler library
+target_link_libraries(baa PRIVATE baa_compiler_lib BaaCommonSettings) # main.c links only the compiler library
 # Include directories and compile definitions for the 'baa' executable
 target_include_directories(baa PRIVATE
     ${CMAKE_SOURCE_DIR}/include
     ${CMAKE_SOURCE_DIR}/src       # Allow includes like "lexer/lexer_char_utils.h" or relative from within src
-)
-
-target_compile_definitions(baa PRIVATE
-    UNICODE
-    _UNICODE
-    _CRT_SECURE_NO_WARNINGS
 )
 
 # --- Conditional LLVM Handling ---
@@ -79,6 +78,7 @@ add_executable(baa_preprocessor_tester
 target_link_libraries(baa_preprocessor_tester PRIVATE
     baa_preprocessor
     baa_utils
+    BaaCommonSettings
 )
 
 # Include directories for the preprocessor tester
@@ -88,11 +88,6 @@ target_include_directories(baa_preprocessor_tester
         ${CMAKE_SOURCE_DIR}/src/preprocessor # For preprocessor_internal.h
 )
 
-target_compile_definitions(baa_preprocessor_tester PRIVATE
-    UNICODE
-    _UNICODE
-    _CRT_SECURE_NO_WARNINGS
-)
 
 # --- Standalone Lexer Tester ---
 add_executable(baa_lexer_tester
@@ -103,6 +98,7 @@ add_executable(baa_lexer_tester
 target_link_libraries(baa_lexer_tester PRIVATE
     baa_lexer
     baa_utils
+    BaaCommonSettings
 )
 
 # Include directories for the lexer tester
@@ -110,12 +106,6 @@ target_include_directories(baa_lexer_tester
     PRIVATE
         ${CMAKE_SOURCE_DIR}/include  # For baa/lexer/lexer.h and baa/utils/*.h
         ${CMAKE_SOURCE_DIR}/src/lexer # For lexer_internal.h if needed by included lexer files
-)
-
-target_compile_definitions(baa_lexer_tester PRIVATE
-    UNICODE
-    _UNICODE
-    _CRT_SECURE_NO_WARNINGS
 )
 
 # تفعيل الاختبارات (معطل مؤقتاً)

--- a/README.md
+++ b/README.md
@@ -1,297 +1,231 @@
 # B (باء) Programming Language
 
-B (باء) is a programming language designed to support Arabic syntax while maintaining full compatibility with K&R C features. It allows developers to write code using Arabic keywords and identifiers while following established C programming patterns.
+B (باء) is a programming language designed to support Arabic syntax while maintaining conceptual alignment with C features. It allows developers to write code using Arabic keywords and identifiers. The project aims to provide a complete compiler toolchain, including a preprocessor, lexer, parser, semantic analyzer, and code generator.
 
-## Current Status (v0.1.15.0)
+## Current Status (Reflects Build System v0.1.18.0 / Preprocessor v0.1.17.0)
 
-The project now supports:
+The project is actively under development. Key components and their status:
 
-### Core Features
+### Core Features & Status
 
-- **Preprocessor Directives:**
-  - `#تضمين <...>` and `#تضمين "..."` (Include files)
-  - `#تعريف NAME ...` (Parameterless and function-like macro definition/substitution, **including rescanning of expansion results**).
-  - `#خطأ "message"` (Error directive - stops preprocessing) - *[Implemented]*
-  - `#تحذير "message"` (Warning directive - prints to stderr, continues) - *[Implemented]*
-  - `#الغاء_تعريف NAME` (Undefine macro)
-  - Conditional compilation (`#إذا_عرف`, `#إذا_لم_يعرف`, `#إذا`, `#وإلا_إذا`, `#إلا`, `#نهاية_إذا`) with expression evaluation (using `معرف` for `defined`, supports arithmetic, comparison, logical, and **bitwise operators**, and decimal/hex/binary literals).
-  - Stringification (`#`) and Token Pasting (`##`) operators in macros.
-    - Predefined Arabic macros: `__الملف__` (FILE), `__السطر__` (LINE - expands to integer), `__التاريخ__` (DATE), `__الوقت__` (TIME), `__الدالة__` (expands to placeholder `L"__BAA_FUNCTION_PLACEHOLDER__"`), `__إصدار_المعيار_باء__` (expands to current version, e.g., `10150L`). - *[All Implemented]*
-    - Variadic Macros (using `وسائط_إضافية` for `...`, and `__وسائط_متغيرة__` for `__VA_ARGS__`). - *[Implemented]*
-    - Other Standard Directives (Planned: `#سطر`, `#براغما`, and `أمر_براغما` operator).
+* **Build System (CMake):**
+  * **Refactored:** Now uses a modular, target-centric approach. Component libraries (utils, types, lexer, preprocessor, etc.) are built as static libraries and linked explicitly.
+  * **Out-of-Source Builds Enforced.**
+  * **Common Compile Definitions:** Managed via an interface library `BaaCommonSettings` (defined in `cmake/BaaCompilerSettings.cmake`).
+  * LLVM integration is conditional and handled by the `baa_codegen` library.
 
-- **Basic Type System (نظام الأنواع الأساسي):** (K&R C compatibility with Arabic keywords)
-  - `عدد_صحيح` (int) - 32-bit integer
-  - `عدد_حقيقي` (float) - 32-bit float
-  - `حرف` (char) - 16-bit UTF-16 character
-  - `منطقي` (boolean) - Logical true/false values (`صحيح`, `خطأ`)
-  - `فراغ` (void) - No value type
-  - (Planned: `عدد_صحيح_طويل_جدا` for long long int)
+* **Preprocessor (`src/preprocessor/`):** - *Actively Developed & Largely Functional*
+  * Handles file inclusion (`#تضمين`) with relative and standard path resolution, circular include detection.
+  * Supports macro definitions (`#تعريف`) including object-like, function-like (with parameters, stringification `#`, token pasting `##`, variadic arguments `وسائط_إضافية`/`__وسائط_متغيرة__`), and rescanning of expansion results.
+  * Handles `#الغاء_تعريف` (undefine).
+  * Implements conditional compilation (`#إذا`, `#إذا_عرف`, `#إذا_لم_يعرف`, `#وإلا_إذا`, `#إلا`, `#نهاية_إذا`) with expression evaluation (supports arithmetic, comparison, logical, bitwise operators, decimal/hex/binary literals, and the `معرف` operator).
+  * Provides predefined Arabic macros (`__الملف__`, `__السطر__` as integer, `__التاريخ__`, `__الوقت__`, `__الدالة__` placeholder, `__إصدار_المعيار_باء__`).
+  * Supports `#خطأ` and `#تحذير` directives.
+  * Input file encoding detection (UTF-8 default, UTF-16LE with BOM). Outputs UTF-16LE `wchar_t*` stream.
+  * Error reporting provides original source locations (file, line, column) and is being enhanced for multi-error reporting.
+  * *See `docs/PREPROCESSOR_ROADMAP.md` and `CHANGELOG.md` for latest features and known issues.*
 
-- **Core Operator System (نظام المعاملات الأساسي):**
-  - Arithmetic operators (+, -, *, /, %)
-  - Comparison operators (==, !=, <, >, <=, >=)
-  - Assignment operator (=)
-  - Compound assignment operators (+=, -=, *=, /=, %=)
-  - Increment/decrement operators (`++`, `--`)
-  - Logical operators (`&&`, `||`, `!`)
-  - Type checking and validation
-  - Arabic operator names
+* **Lexer (`src/lexer/`):** - *Actively Developed & Largely Functional*
+  * Tokenizes preprocessed UTF-16LE stream.
+  * Supports Arabic/English identifiers, Arabic-Indic digits, Arabic keywords.
+  * Handles numeric literals (decimal, hex `0x`, binary `0b`, underscores, Arabic decimal separator `٫`, basic scientific `e/E`). Arabic suffixes (`غ`, `ط`, `طط`) are tokenized.
+  * Handles string (`"..."`, multiline `"""..."""`, raw `خ"..."`) and character (`'...'`) literals with standard C & Unicode (`\uXXXX`) escapes.
+  * Recognizes documentation comments (`/** ... */`).
+  * Accurate line/column tracking and error reporting for lexical errors.
+  * *See `docs/LEXER_ROADMAP.md` for planned enhancements (e.g., Arabic exponent `أ`, float suffix `ح`, Arabic escapes).*
 
-- **Control Flow Structures (بنى التحكم في التدفق):**
-  - `إذا`/`وإلا` (if/else)
-  - `طالما` (while)
-  - `لكل` (for - uses C-style semicolons internally)
-  - `إرجع` (return)
-  - `توقف` (break)
-  - `أكمل` (continue)
-  - `اختر`/`حالة`/`افتراضي` (switch/case/default)
-  - (Planned: `افعل` for do-while, `تعداد` for enum)
+* **Parser (`src/parser/`):** - **Under Redesign/Re-implementation**
+  * The previous parser implementation has been removed to facilitate a complete redesign.
+  * **(Planned)** Will transform the token stream from the lexer into an Abstract Syntax Tree (AST).
+  * **(Planned)** Will use a recursive descent approach and focus on syntactic validation, deferring semantic checks.
+  * *Refer to `docs/PARSER.md` and `docs/PARSER_ROADMAP.md` for new design plans.*
 
-- **Function System (نظام الدوال):** (Uses C-style declarations: `return_type name(params)`)
-  - Regular function parameters
-  - Optional parameters (with default values)
-  - Rest parameters (variable argument lists)
-  - Named arguments support
-  - Method vs. function distinction
+* **Abstract Syntax Tree (AST):** - **Under Redesign/Re-implementation**
+  * The previous AST implementation has been removed.
+  * **(Planned)** Will provide a structured representation of the parsed code.
+  * **(Planned)** Node types for expressions, statements, declarations, etc., with standardized memory management.
+  * *Refer to `docs/AST.md` and `docs/AST_ROADMAP.md` for new design plans.*
 
-- Literals
-  - **Numeric Literals:**
-    - Integers: Decimal (Western `0-9` & Arabic-Indic `٠-٩`), Binary (`0b`/`0B`), Hexadecimal (`0x`/`0X`). (Planned: Arabic suffixes like `غ` for unsigned, `ط` for long, `طط` for long long).
-    - Floats: Using `.` or Arabic `٫` as decimal separator. Scientific notation (using `أ` as exponent marker). (Planned: Arabic suffix `ح` for float).
-    - Underscores (`_`) supported as separators in all number types.
-    - Examples: `123`, `١٢٣غ`, `0b1010طط`, `0xFACEط`, `1_000_000`, `3.14ح`, `٣٫١٤`, `1.5أ-2`.
-  - **String Literals:** `"..."` (Planned: Arabic escapes like `\س`, `\م` using `\` as escape char).
-  - **Character Literals:** `'...'` (Planned: Arabic escapes like `\س`, `\م` using `\` as escape char).
-  - **Boolean Literals:** `صحيح` (true), `خطأ` (false).
-  - (Planned: `تعداد` keyword for enumerations).
-  - (Planned: Struct/union member access using `::` for direct and `->` for pointer).
+* **Type System (`src/types/`):** - *Core Implemented*
+  * Basic types implemented (`عدد_صحيح` int, `عدد_حقيقي` float, `حرف` char, `منطقي` bool, `فراغ` void).
+  * Basic type checking and conversion rules defined.
+  * Array type support (`BAA_TYPE_ARRAY`) exists at the type system level.
 
-- Arabic File Support
-  - Native `.ب` extension
-  - UTF-16LE encoding support
-  - Arabic file naming
-  - Build system integration
+* **Operators (`src/operators/`):** - *Core Implemented*
+  * Definitions for arithmetic, comparison, logical, and assignment operators.
+  * Operator precedence table defined.
+  * Basic type validation for operators.
 
-For detailed information about Arabic support, see [Arabic Support Documentation](docs/arabic_support.md).
+* **Analysis (`src/analysis/`):** - *Initial Placeholders / AST Dependent*
+  * `flow_analysis.c` contains stubs for control flow analysis, previously dependent on the old AST.
+  * **(Planned)** Semantic analysis, including symbol table management, name resolution, full type checking, and advanced flow analysis, will be developed to work with the new AST.
+  * *See `docs/SEMANTIC_ANALYSIS.md` and `docs/SEMANTIC_ANALYSIS_ROADMAP.md`.*
 
-### Project Status Overview
+* **Code Generation (`src/codegen/`):** - *Basic Stubs / LLVM Integration Planned*
+  * LLVM backend is optional (controlled by `USE_LLVM` CMake option).
+  * If LLVM is disabled or not found, a stub backend (`llvm_stub.c`) is used.
+  * Actual LLVM IR generation from an AST is **pending** the new Parser/AST implementation and further development of `llvm_codegen.c`.
+  * *See `docs/LLVM_CODEGEN.md` and `docs/LLVM_CODEGEN_ROADMAP.md`.*
 
-#### What's Working
+* **Utilities (`src/utils/`):** - *Implemented*
+  * Memory management wrappers (`baa_malloc`, `baa_free`, `baa_strdup`).
+  * String handling utilities.
+  * Basic file I/O helpers.
 
-- **Preprocessor**: Handles includes (`#تضمين`), object-like and function-like macros (`#تعريف` with parameters, including variadic macros using `وسائط_إضافية`/`__وسائط_متغيرة__`, `#`, `##`, and **rescanning**), undefines (`#الغاء_تعريف`), conditional compilation (including expression evaluation for `#إذا`/`#وإلا_إذا`), predefined Arabic macros (`__الملف__`, `__السطر__` (as integer), `__التاريخ__`, `__الوقت__`). Error reporting is unified and provides original source locations (file, line, column).
-- **Core Architecture**: Well-defined architecture with clear separation of concerns.
-- **Type System**: Basic types including Boolean, type conversion rules, and type checking
-- **Lexer**: UTF-16LE file processing (from preprocessor output). Modularized structure. Robust token recognition for keywords, identifiers (Arabic/English), types, boolean literals, all operators. Advanced numeric literal scanning (Arabic-Indic digits, binary/hex prefixes, underscores, Arabic decimal separator `٫`, scientific notation). String and character literal scanning with standard and Unicode escapes. Accurate line/column tracking and error reporting.
-- **Utils**: Memory management, string handling, error infrastructure
-- **Preprocessor integration with include and basic macro support.**
+### Overall Project Status
 
-#### What's Not Working
-
-- **Parser**: Currently under redesign and re-implementation after removal of the old version. Syntactic analysis of token streams is not yet functional.
-- **AST (Abstract Syntax Tree)**: Currently under redesign and re-implementation. Structured representation of code is not yet available.
-- **Code Generation**: LLVM integration is incomplete, mostly placeholder code
-- **Standard Library**: Defined but not implemented
-- **Testing Infrastructure**: Framework defined but implementation is limited
-
-#### What Needs Improvement
-
-- **Arabic Support**: RTL text handling, more comprehensive error messages
-- **Error Handling**: More detailed messages. Preprocessor error recovery mechanisms (reporting multiple errors) and location precision are under ongoing improvement.
-- **Documentation**: Generally updated and consolidated. Parser and AST documentation reflect their "New Design" status. High-level docs (like this README and architecture.md) are being updated to reflect current Parser/AST status.
-- **Build System**: Cross-platform support, dependency management
-
-#### What Needs Fixing
-
-- **Lexer Issues**: Ongoing review for full UTF-16LE handling and complete Arabic character/literal feature set.
-- **Memory Management**: Potential leaks, inconsistent allocation
-- **Preprocessor Known Issues**:
-- Token pasting (`##`) during rescanning (complex cases).
-- Full macro expansion in conditional expressions.
-- `معرف` operator argument expansion in conditional expressions (argument expands before `معرف` evaluation).
-
-- **Integration Issues**: Component integration, compilation pipeline gaps
+* **What's Working Well:**
+  * **Preprocessor:** Handles most C99-level features with Arabic syntax.
+  * **Lexer:** Robust tokenization of Baa syntax, including good Arabic numeral and string support.
+  * **Core Types & Operators:** Foundational system in place.
+  * **CMake Build System:** Modular and correctly links components.
+* **What's Actively Being Rebuilt/Designed:**
+  * **Parser**
+  * **Abstract Syntax Tree (AST)**
+* **What's Planned/Blocked:**
+  * **Semantic Analysis** (depends on new AST)
+  * **Code Generation** (LLVM IR from AST, depends on new AST & Semantic Analysis)
+  * Comprehensive **Standard Library**.
+* **General:**
+  * Error reporting is being continuously improved for precision and clarity.
+  * Full Arabic localization of all error messages and tool outputs is ongoing.
 
 ### Roadmap
 
-**Completed Features:**
+* **Short-term Goals (towards 0.2.0 and beyond):**
+    1. **Critical: Re-implement Parser and AST** based on new designs. This is the current main focus.
+    2. Continue enhancing Preprocessor and Lexer (see their respective roadmaps).
+    3. Begin foundational Semantic Analysis once the new AST is stable.
+    4. Develop Code Generation (LLVM) based on the new, semantically-analyzed AST.
+* *For a high-level overview, see `docs/roadmap.md`. For component-specific details, refer to `LEXER_ROADMAP.md`, `PARSER_ROADMAP.md`, `AST_ROADMAP.md`, `PREPROCESSOR_ROADMAP.md`, etc.*
 
-- **Type System, Operators, Memory Management, Error Handling (Core Utils)**
-- **Preprocessor (significant C99 feature alignment)**
-- **Lexer (robust tokenization, advanced numeric literals, Arabic support)**
-- Advanced operators (compound assignment, increment/decrement)
-- Boolean type support
-- Arabic support (UTF-16LE encoding, Arabic identifiers, Basic RTL support, Arabic error messages)
-- Documentation (Language specification, Arabic support guide, C comparison, Architecture overview, Component documentation)
+## Project Structure
 
-**In Progress:**
-
-- Parser Development (Grammar definition, Token handling, Error recovery, Source location tracking)
-- **Code Generation (LLVM integration - Blocked by Parser/AST)**
-- Standard Library (Basic I/O functions, String manipulation, Memory management, File operations)
-
-**Short-term Goals (0.2.0):**
-
-- **Critical:** Re-implement Parser and AST based on new designs.
-- Enhance Preprocessor and Lexer with remaining planned features.
-- Begin foundational Code Generation work once Parser/AST are stable.
-- *See [docs/roadmap.md](docs/roadmap.md) for the high-level plan and component-specific roadmaps (e.g., `docs/LEXER_ROADMAP.md`) for details.*
-
-### Project Structure
+The project is organized modularly:
 
 ```
+
 baa/
-├── include/
-│   └── baa/           # Public header files
-│       ├── ast/       # AST definitions
-│       ├── lexer/     # Lexer interface
-│       ├── parser/    # Parser interface
-│       ├── preprocessor/ # Preprocessor interface
-│       ├── types/     # Type system interface
-│       ├── utils/     # Utility functions
-│       └── codegen/   # Code generation interface
-├── src/
-│   ├── ast/          # AST implementation
-│   ├── lexer/        # Lexer implementation
-│   ├── parser/       # Parser implementation
-│   ├── preprocessor/ # Preprocessor implementation
-│   ├── types/        # Type system implementation
-│   ├── operators/    # Operator system implementation
-│   ├── codegen/      # Code generation (incomplete)
-│   ├── utils/        # Utility functions
-│   ├── control_flow/ # Control flow implementation
-│   ├── compiler.c    # Main compilation logic
-│   └── main.c        # Executable entry point
-├── tests/
-│   ├── unit/         # Unit tests (limited)
-│   └── integration/  # Integration tests (placeholder)
-└── docs/             # Documentation
-    ├── preprocessor.md     # Preprocessor documentation
-    ├── PREPROCESSOR_ROADMAP.md # Detailed Preprocessor roadmap
-    ├── architecture.md     # System architecture overview & component status
-    ├── language.md         # Language specification
-    ├── project_structure.md # Detailed directory layout (Arabic)
-    ├── roadmap.md          # High-level development roadmap
-    ├── lexer.md            # Lexer structure & usage
-    ├── LEXER_ROADMAP.md    # Detailed Lexer roadmap
-    ├── AST_STRUCTURE.md    # AST structure details
-    ├── AST_ROADMAP.md      # Detailed AST roadmap
-    ├── PARSER_STRUCTURE.md # Parser structure details
-    ├── PARSER_ROADMAP.md   # Detailed Parser roadmap
-    ├── arabic_support.md   # Arabic support details
-    ├── c_comparison.md     # Comparison with C
-    ├── development.md      # Developer guide
-    └── ...                 # Other specific docs
+├── cmake/                  # Custom CMake modules (e.g., BaaCompilerSettings.cmake)
+├── docs/                   # Documentation
+├── include/                # Public header files (organized by component)
+│   └── baa/
+├── src/                    # Source code (organized by component)
+│   ├── CMakeLists.txt      # Adds component subdirectories
+│   ├── analysis/
+│   ├── codegen/
+│   ├── compiler.c          # Core compiler logic (part of baa_compiler_lib)
+│   ├── lexer/
+│   ├── main.c              # Main executable entry point
+│   ├── operators/
+│   ├── preprocessor/
+│   ├── types/
+│   └── utils/
+├── tests/                  # Unit and integration tests
+└── tools/                  # Standalone utility executables
+
 ```
+
+*For a more detailed visual structure, see `docs/project_structure.md`.*
 
 ## Building from Source
 
 ### Prerequisites
 
-- CMake 3.20 or higher
-- K&R C compliant compiler
-- Git for version control
-- LLVM development libraries (optional, for code generation)
-- Unicode support libraries
+* CMake (3.20 or higher)
+* A C11 compliant C compiler (Clang-cl is used for Windows in CI)
+* Git
+* (Optional) LLVM development libraries (for the LLVM backend)
 
 ### Build Steps
 
-```bash
-git clone <repository-url>
-cd baa
-mkdir build && cd build
-cmake ..
-cmake --build .
-```
+It is **required** to perform an out-of-source build.
 
-### Running Tests
+1. Clone the repository:
 
-```bash
-cd build
-ctest --output-on-failure
-```
+    ```bash
+    git clone <repository-url>
+    cd baa
+    ```
 
-### Preprocessor Tester
+2. Create a build directory:
 
-A standalone tool is available to test the preprocessor in isolation:
+    ```bash
+    mkdir build
+    cd build
+    ```
 
-```bash
-# After building the project:
-./build/bin/baa_preprocessor_tester <path/to/your/file.baa>
-```
+3. Configure using CMake (from the `build` directory):
+    * **Windows (with Clang-cl from LLVM tools):**
 
-Note: The preprocessor currently expects input files to be encoded in UTF-16LE with a BOM.
+        ```bash
+        cmake -G "Ninja" -DCMAKE_C_COMPILER="C:/Program Files/LLVM/bin/clang-cl.exe" ..
+        ```
 
-## Features
+        *(Adjust path to `clang-cl.exe` as needed. `-DCMAKE_CXX_COMPILER` can also be set similarly if C++ parts were present.)*
+    * **Linux/macOS (using system default C compiler, e.g., GCC or Clang):**
 
-### Type Safety
+        ```bash
+        cmake -G "Ninja" ..
+        ```
 
-- Strong type checking
-- Explicit conversion rules
-- Error type for invalid operations
-- UTF-16 support for Arabic text
+    * **To enable the LLVM backend (if LLVM is installed):**
+        Add `-DUSE_LLVM=ON` to your cmake command. You might need `-DLLVM_DIR=/path/to/llvm/lib/cmake/llvm` if CMake can't find LLVM automatically.
 
-### Operator System
+4. Build the project:
 
-- Type-safe operations
-- Arabic operator names
-- K&R C operator precedence
-- Comprehensive error handling
+    ```bash
+    cmake --build .
+    # Or, if using Ninja generator:
+    # ninja
+    ```
 
-### Documentation
+    Executables will be in the `build` directory (e.g., `baa.exe`, `baa_lexer_tester.exe`).
 
-- Detailed Arabic error messages
-- Comprehensive documentation in both English and Arabic
-- Examples and usage guides
-- Development guidelines
+### Running Tool Executables
 
-## File Extensions
+* **Preprocessor Tester:**
 
-The Baa programming language supports two file extensions:
+    ```bash
+    # After building:
+    ./baa_preprocessor_tester <path/to/your/file.baa>
+    ```
 
-- `.ب` - The primary Arabic file extension
-- `.baa` - Alternative Latin file extension
+* **Lexer Tester:**
+
+    ```bash
+    # After building:
+    ./baa_lexer_tester <path/to/your/file.baa>
+    ```
+
+## Language Highlights (Current & Planned)
+
+* **Arabic Syntax:** Keywords, identifiers, and planned support for more Arabic constructs.
+* **Preprocessor:** C99-compliant features with Arabic directives.
+* **Type System:** Static typing with basic C types and Arabic names.
+* **Literals:** Support for Arabic-Indic digits, Arabic decimal separator, underscores in numbers, and various string literal formats.
+* **Statement Terminator:** Uses `.` (dot) instead of `;`.
+* *For full details, see `docs/language.md` and `docs/arabic_support.md`.*
 
 ### Example Program
 
 ```baa
-#تضمين <مكتبة_طباعة> // Assuming a Baa standard library header
+// program.baa
+#تضمين <مكتبة_افتراضية_للطباعة> // Assuming a standard Baa print library
+
 #تعريف EXIT_SUCCESS 0
 
-// مثال برنامج بسيط بلغة باء
 // Baa uses C-style function declarations
 عدد_صحيح رئيسية() {
-    اطبع("مرحباً بالعالم!").
+    اطبع("!مرحباً بالعالم"). // Hypothetical print function
     إرجع EXIT_SUCCESS.
 }
 ```
 
-## Known Issues and Limitations
-
-- Code generation is not fully implemented yet
-- Complex language constructs may not parse correctly
-- Error messages may not be fully localized
-- Limited testing coverage
-- UTF-16LE handling has edge cases with certain characters
-- Parser error recovery is limited
-
 ## Contributing
 
-We welcome contributions! Please see our [development guide](docs/development.md) for details on:
-
-- Code style and standards
-- Testing requirements
-- Documentation guidelines
-- Pull request process
+Contributions are welcome! Please refer to `docs/development.md` for coding standards, build system details, and component implementation guidelines. Key areas for contribution currently include the Parser and AST redesign and implementation.
 
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## Acknowledgments
-
-Special thanks to:
-
-- The C language designers for their foundational work
-- The Arabic programming community for their support and feedback
-- All contributors who have helped shape this project

--- a/cmake/BaaCompilerSettings.cmake
+++ b/cmake/BaaCompilerSettings.cmake
@@ -1,0 +1,16 @@
+# cmake/BaaCompilerSettings.cmake
+
+if(NOT TARGET BaaCommonSettings)
+    add_library(BaaCommonSettings INTERFACE)
+    target_compile_definitions(BaaCommonSettings INTERFACE
+        UNICODE
+        _UNICODE
+        _CRT_SECURE_NO_WARNINGS
+    )
+    # Add other common project-wide compile options or definitions here if needed
+    # For example:
+    # target_compile_options(BaaCommonSettings INTERFACE
+    #   $<$<COMPILE_LANGUAGE:C>:-Wall;-Wextra> # Example for GCC/Clang
+    #   $<$<COMPILE_LANGUAGE:C>:$<$<CXX_COMPILER_ID:MSVC>:/W4>> # Example for MSVC
+    # )
+endif()

--- a/docs/CMAKE_ROADMAP.md
+++ b/docs/CMAKE_ROADMAP.md
@@ -1,43 +1,75 @@
 # Baa Language CMake Build System Roadmap
 
-This document outlines potential future improvements for the Baa project's CMake build system, aiming for increased modularity, maintainability, and adherence to modern CMake practices.
+This document outlines the evolution and future improvements for the Baa project's CMake build system, aiming for increased modularity, maintainability, and adherence to modern CMake practices.
 
-**Note:** This is a planning document; these changes are not yet implemented.
+**Current Status (as of Build System v0.1.18.0):**
 
-## Proposed Refactoring Plan
+The CMake build system has undergone a major refactoring towards a target-centric and modular design.
 
-1.  **Create `cmake/` Directory:**
-    *   Establish a `cmake/` directory at the project root.
-    *   Move LLVM finding logic from the root `CMakeLists.txt` into a dedicated module (e.g., `cmake/FindLLVM.cmake`).
-    *   Consider creating modules for common compiler settings (e.g., C standard, UTF-8 flags) to be included where needed (e.g., `cmake/BaaCompilerSettings.cmake`).
+**Completed Refactoring Steps:**
 
-2.  **Enforce Out-of-Source Builds:**
-    *   Add a check to the root `CMakeLists.txt` to prevent in-source builds and guide users to create a separate build directory.
+1. **Enforce Out-of-Source Builds:**
+    * A check has been added to the root `CMakeLists.txt` to prevent in-source builds and guide users to create a separate build directory.
 
-3.  **Adopt Target-Centric Approach:**
-    *   **Remove Global Settings:** Eliminate global `include_directories()`, `add_definitions()`, and `set(CMAKE_C_FLAGS ...)` from the root `CMakeLists.txt`.
-    *   **Apply Per-Target:** Ensure all component libraries (`baa_utils`, `baa_lexer`, etc.) use `target_include_directories()`, `target_compile_definitions()`, and `target_compile_options()` with appropriate visibility (`PUBLIC`, `PRIVATE`, `INTERFACE`).
+2. **Adopt Target-Centric Approach:**
+    * **Global Settings Removed/Migrated:** Global `include_directories()` and `add_definitions()` have been removed from the root `CMakeLists.txt`.
+    * **Per-Target Properties:** Component libraries (e.g., `baa_utils`, `baa_lexer`) and executables now use `target_include_directories()`, `target_compile_definitions()`, and `target_compile_options()` with appropriate visibility (`PUBLIC`, `PRIVATE`, `INTERFACE`).
+    * Common compile definitions like `UNICODE`, `_UNICODE`, `_CRT_SECURE_NO_WARNINGS` are managed by an interface library `BaaCommonSettings`.
 
-4.  **Declare Dependencies Explicitly:**
-    *   Modify each component's `CMakeLists.txt` (in `src/*`) to explicitly link against its direct dependencies using `target_link_libraries()`.
-        *   Example: `target_link_libraries(baa_lexer PRIVATE baa_utils)`
-        *   Example: `target_link_libraries(baa_parser PRIVATE baa_lexer baa_ast baa_utils baa_operators)` (already partially done)
-    *   This allows CMake to manage the build order and transitive dependencies correctly.
+3. **Declare Dependencies Explicitly:**
+    * Each component's `CMakeLists.txt` (in `src/*`) now explicitly links against its direct Baa library dependencies using `target_link_libraries(... PRIVATE ...)` (e.g., `baa_types` links `baa_utils`). This allows CMake to correctly manage build order and transitive dependencies.
 
-5.  **Refine Executable Linking:**
-    *   Consider creating a `baa_compiler` library target in `src/` containing `compiler.c`.
-    *   Modify the root `CMakeLists.txt` to link the final `baa` executable primarily against `baa_compiler` (and potentially `baa_preprocessor` if used directly by `main.c`), relying on transitive linking for other components.
+4. **Refine Executable Linking:**
+    * The main `baa` executable and tool executables (`baa_lexer_tester`, `baa_preprocessor_tester`) now link against the component static libraries they require, instead of compiling all sources directly.
+    * A `baa_compiler_lib` static library has been created from `src/compiler.c`. The `baa` executable (from `src/main.c`) links against `baa_compiler_lib`, which in turn consolidates dependencies on other Baa components (lexer, preprocessor, types, utils, etc.).
 
-6.  **CMake Policies:**
-    *   Add relevant `cmake_policy(SET ...)` commands at the top of the root `CMakeLists.txt` to ensure consistent behavior across CMake versions (e.g., CMP0074).
+5. **CMake Policies:**
+    * Relevant CMake policies (CMP0074, CMP0067, CMP0042) have been set in the root `CMakeLists.txt` to ensure modern and consistent CMake behavior.
 
-7.  **Conditional Component Logic:**
-    *   Move conditional logic (like `SKIP_PARSER`) from component `CMakeLists.txt` files to the root file, wrapping the corresponding `add_subdirectory()` calls.
+6. **LLVM Handling Centralized:**
+    * The decision to use LLVM (`USE_LLVM` option and `find_package(LLVM)`) is made in the root `CMakeLists.txt`.
+    * The `baa_codegen` library's `CMakeLists.txt` now conditionally includes LLVM sources (`llvm_codegen.c` or `llvm_stub.c`), sets `LLVM_AVAILABLE` definition, adds LLVM include directories, and links LLVM libraries based on the `USE_LLVM` option and `LLVM_FOUND` status.
 
-## Benefits
+**Benefits Achieved:**
 
-*   Improved modularity and separation of concerns.
-*   Clearer dependency graph.
-*   More robust handling of include paths and compile options.
-*   Easier maintenance and extension of the build system.
-*   Better alignment with modern CMake best practices.
+* Improved modularity and clear separation of concerns for each Baa component.
+* A clearer dependency graph, managed by CMake.
+* More robust and maintainable handling of include paths and compile options/definitions.
+* Better alignment with modern CMake best practices.
+
+---
+
+## Future Improvements / Remaining Roadmap Items
+
+While the major refactoring is complete, the following items from the original roadmap or new ideas can be considered for further enhancement:
+
+1. **Complete `cmake/` Directory Modularization:**
+    * **LLVM Setup Module:** Move the `option(USE_LLVM ...)` and `if(USE_LLVM) find_package(LLVM ...) endif()` logic from the root `CMakeLists.txt` into a dedicated module (e.g., `cmake/LLVMSetup.cmake`).
+        * The root `CMakeLists.txt` would then simply `include(LLVMSetup)`.
+        * This module could set cache variables like `BAA_LLVM_FOUND`, `BAA_LLVM_INCLUDE_DIRS`, `BAA_LLVM_LIBRARIES_LIST` that `src/codegen/CMakeLists.txt` can then consume.
+    * **Refine `BaaCompilerSettings.cmake`:**
+        * Consider moving the C standard settings (`set(CMAKE_C_STANDARD 11)`, `set(CMAKE_C_STANDARD_REQUIRED ON)`) into this module and applying them via the `BaaCommonSettings` interface library or a dedicated function.
+        * Review if other project-wide compiler flags (like `-finput-charset=UTF-8 -fexec-charset=UTF-8` currently in `tests/CMakeLists.txt`) should be part of `BaaCommonSettings` if applicable to all targets.
+
+2. **Testing Infrastructure Integration:**
+    * Ensure `enable_testing()` and `add_subdirectory(tests)` are correctly placed and functional in the root `CMakeLists.txt` when tests are fully active.
+    * Review `tests/CMakeLists.txt` for applying common settings (like `BaaCommonSettings`) to test executables.
+
+3. **Installation Rules:**
+    * Define `install()` rules for the `baa` executable, tool executables, and any public headers/libraries if the project is intended to be installable.
+    * Consider using `GNUInstallDirs` for standard installation paths.
+
+4. **Package Configuration File (for `find_package`):**
+    * If `baa` itself is intended to be used as a library by other CMake projects, generate a `BaaConfig.cmake` and `BaaConfigVersion.cmake` file upon installation. This allows downstream projects to easily find and use Baa components via `find_package(Baa)`.
+
+5. **Code Coverage Setup (Optional):**
+    * Integrate tools for generating code coverage reports (e.g., using `gcov`/`lcov` with GCC/Clang).
+
+6. **Static Analysis Integration (Optional):**
+    * Add options to integrate static analysis tools like `clang-tidy` or `cppcheck` into the build process.
+
+7. **Conditional Component Logic (Review):**
+    * The original roadmap mentioned: "Move conditional logic (like `SKIP_PARSER`) from component `CMakeLists.txt` files to the root file, wrapping the corresponding `add_subdirectory()` calls."
+    * With the parser removed, this specific example is moot. However, if other components become optional in the future, this pattern should be followed. Ensure the current `USE_LLVM` logic correctly gates the LLVM-specific parts of `baa_codegen`.
+
+These future steps aim to further refine the build system's organization, add more advanced features like installation and packaging, and integrate more development tools. The current refactored state provides a solid foundation.

--- a/docs/c_comparison.md
+++ b/docs/c_comparison.md
@@ -2,412 +2,182 @@
 
 ## Overview
 
-This document compares C99 features with their B (باء) equivalents and outlines the implementation roadmap for achieving full C99 compatibility.
+This document compares C99 language features with their B (باء) equivalents. Baa aims for conceptual alignment with many C features while introducing Arabic syntax and potentially some modern constructs. The status column reflects the current state of implementation (Lexer, Preprocessor, Core Systems) or planning for future phases (Parser, AST, Semantic Analysis, Code Generation).
+
+**Note:** "Implemented (Lexer/PP)" means the syntax is recognized by the lexer or handled by the preprocessor. Full parsing, semantic validation, and code generation for these features are often pending the new Parser/AST and subsequent compiler stages.
 
 ## Language Features
 
 ### Basic Types
 
-| C99 Feature | B (باء) Equivalent | Status      | Notes |
-|---------------|--------------------|-------------|-------|
-| `char`        | `حرف`             | Implemented | 16-bit (`wchar_t`) for Unicode support in Baa. |
-| `int`         | `عدد_صحيح`        | Implemented | 32-bit integer (`int`). |
-| `float`       | `عدد_حقيقي`      | Implemented | 32-bit floating point (`float`). |
-| `void`        | `فراغ`            | Implemented | Type exists. |
-| _Bool/bool    | `منطقي`           | Implemented | Boolean type exists; Baa uses `صحيح`/`خطأ` literals. |
-| `long long int` | `عدد_صحيح_طويل_جدا` | Planned | C99 standard. 64-bit integer. |
-| `enum`        | `تعداد`            | Planned | Baa keyword for enumerations. |
+| C99 Feature     | B (باء) Equivalent        | Status                 | Notes                                                                 |
+|-----------------|---------------------------|------------------------|-----------------------------------------------------------------------|
+| `char`          | `حرف`                    | Implemented (Core/Lexer) | Baa `حرف` is 16-bit (`wchar_t`) for Unicode.                          |
+| `int`           | `عدد_صحيح`               | Implemented (Core/Lexer) | Typically 32-bit signed integer.                                        |
+| `float`         | `عدد_حقيقي`              | Implemented (Core/Lexer) | Typically 32-bit floating point.                                      |
+| `double`        | `عدد_حقيقي` (modifier)    | Planned (Semantic/CodeGen) | Baa `عدد_حقيقي` might be `float` or `double` based on context/suffix. |
+| `long double`   | (No direct equivalent yet) | Planned (Future)       |                                                                       |
+| `void`          | `فراغ`                   | Implemented (Core/Lexer) | Represents no value.                                                  |
+| `_Bool`/`bool`  | `منطقي`                  | Implemented (Core/Lexer) | Literals: `صحيح` (true), `خطأ` (false).                             |
+| `short int`     | `عدد_صحيح` (modifier)    | Planned (Semantic/CodeGen) |                                                                       |
+| `long int`      | `عدد_صحيح` (modifier `ط`) | Planned (Semantic/CodeGen) | Via suffix `ط` on literals. Type system needs to distinguish.       |
+| `long long int` | `عدد_صحيح_طويل_جدا`      | Implemented (Lexer Suffix `طط`) / Planned (Type System/Semantic) | Keyword planned. Suffix `طط` on literals. |
+| `unsigned char` | `حرف` (modifier `غ`)      | Planned (Semantic/CodeGen) | Via suffix `غ` on char literals if applicable, or type system.     |
+| `unsigned int`  | `عدد_صحيح` (modifier `غ`) | Planned (Semantic/CodeGen) | Via suffix `غ` on int literals. Type system needs to distinguish.        |
+| ... (other unsigned types) | (modifier `غ`)        | Planned (Semantic/CodeGen) |                                                                       |
+| `enum`          | `تعداد`                   | Planned (Parser/AST)   | Keyword `تعداد` exists.                                                |
 
 ### Derived Types
 
-| C99 Feature | B (باء) Equivalent | Status   | Notes |
-|---------------|--------------------|----------|-------|
-| Arrays        | `مصفوفة`          | Partial  | AST/Type support exists (`BAA_TYPE_ARRAY`, `BAA_EXPR_ARRAY`, `BAA_EXPR_INDEX`). Semantics/analysis likely incomplete. |
-| Pointers      | `مؤشر`            | Planned  | Mentioned in docs, but no clear AST/Type support observed. |
-| Structures    | `بنية`            | Planned  | Member access: `::` (direct), `->` (pointer). |
-| Unions        | `اتحاد`           | Planned  | Member access: `::` (direct), `->` (pointer). |
+| C99 Feature  | B (باء) Equivalent         | Status               | Notes                                                                           |
+|----------------|----------------------------|----------------------|---------------------------------------------------------------------------------|
+| Arrays         | `مصفوفة` (implicit type)  | Planned (Parser/AST) | Array syntax `type name[]` or `type name[size]`. `BAA_TYPE_ARRAY` exists.         |
+| Pointers       | `مؤشر` (implicit type)     | Planned (Full)       | Full pointer arithmetic and dereferencing.                                      |
+| Structures     | `بنية`                     | Planned (Parser/AST) | Member access: `::` (direct), `->` (pointer). C99 flexible array members.   |
+| Unions         | `اتحاد`                    | Planned (Parser/AST) | Member access: `::` (direct), `->` (pointer).                                 |
 
-### Storage Classes
+### Storage Class Specifiers
 
-| C99 Feature | B (باء) Equivalent | Status   | Notes |
-|---------------|--------------------|----------|-------|
-| `auto`        | `تلقائي`          | N/A      | Baa uses type inference or explicit types; `auto` concept less relevant. Keyword not observed. |
-| `static`      | `مستقر`           | Planned  | New keyword for static storage duration and internal linkage. `ثابت` is for `const`. |
-| `extern`      | `خارجي`           | Implemented/Partial  | Keyword exists (`is_extern` flag on `BaaFunction`). Full semantic handling needed. |
-| `register`    | `سجل`             | Planned  | Keyword not observed; likely low priority. |
+| C99 Feature  | B (باء) Equivalent | Status               | Notes                                                                |
+|----------------|--------------------|----------------------|----------------------------------------------------------------------|
+| `auto`         | (No direct keyword) | N/A                  | Baa relies on lexical scope for automatic storage duration.           |
+| `static`       | `مستقر`            | Planned (Parser/AST) | For static storage duration and internal linkage.                     |
+| `extern`       | `خارجي`            | Planned (Parser/AST) | For external linkage.                                                |
+| `register`     | `سجل` (tentative)  | Planned (Low Priority) | Hint to compiler, often ignored by modern compilers.                   |
+| `typedef`      | `نوع_مستخدم`       | Planned (Parser/AST) | To create aliases for types.                                         |
 
 ### Type Qualifiers
 
-| C99 Feature | B (باء) Equivalent | Status   | Notes |
-|---------------|--------------------|----------|-------|
-| `const`       | `ثابت`            | Partial  | Keyword `ثابت` exists and is parsed. Semantic enforcement needed. |
-| `volatile`    | `متطاير`          | Planned  | Keyword not observed. |
-| `restrict`    | `مقيد`            | Planned  | C99 keyword for pointer optimization. |
-| Literal Suffixes U, L, LL, F | `غ`, `ط`, `طط`, `ح` | Planned | Baa uses Arabic suffixes: `غ` (unsigned), `ط` (long), `طط` (long long), `ح` (float). Combinations like `غط` (unsigned long), `غطط` (unsigned long long) are also planned. |
+| C99 Feature | B (باء) Equivalent | Status                     | Notes                                                              |
+|---------------|--------------------|----------------------------|--------------------------------------------------------------------|
+| `const`       | `ثابت`            | Implemented (Lexer/PP) / Planned (Semantic) | Keyword recognized. Semantic enforcement of const-correctness needed. |
+| `volatile`    | `متطاير`           | Planned (Parser/AST)       | For memory that can change unexpectedly.                           |
+| `restrict`    | `مقيد`             | Implemented (Lexer) / Planned (Semantic/CodeGen) | Hint for pointer optimization. Semantic validation needed.        |
 
 ### Literals
 
-| C99 Feature        | B (باء) Equivalent & Extensions                                     | Status      | Notes                                                                                                                               |
-|----------------------|--------------------------------------------------------------------|-------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| Integer Literals     | Decimal (Western & Arabic-Indic), Binary (`0b`/`0B`), Hex (`0x`/`0X`). Underscores (`_`) for readability. Arabic suffixes `غ`, `ط`, `طط` planned. | Implemented | K&R C had decimal, octal, hex. Baa does not explicitly support octal via `0` prefix. |
-| Floating-Point Literals | Decimal point (`.` or `٫`), Scientific notation (using `أ` as exponent marker). Western & Arabic-Indic digits. Underscores for readability. Arabic suffix `ح` planned. | Implemented (exponent `e`/`E`), Planned (exponent `أ`, suffix `ح`) | Baa extends with `٫`, Arabic digits, underscores, and plans Arabic exponent marker `أ` and suffix `ح`. |
-| Character Literals   | `'c'` (Western/Arabic). Arabic escapes planned (e.g., `\س` for newline, `\يXXXX` for Unicode). `\` retained as escape char. | Implemented (Standard Escapes), Planned (Arabic Escapes) | Baa will use `\` with Arabic letters for specific escapes. |
-| String Literals      | `"...\"`, `"""..."""` (multiline), `خ"..."` (raw). (Western/Arabic). Arabic escapes planned. `\` retained as escape char. | Implemented (Standard Escapes), Planned (Arabic Escapes) | Baa will use `\` with Arabic letters for specific escapes. |
+| C99 Feature               | B (باء) Equivalent & Extensions                                                                  | Status (Lexer/PP)   | Notes                                                                                                                                                                 |
+|---------------------------|--------------------------------------------------------------------------------------------------|---------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Integer (dec, oct, hex)   | Dec (Western & Arabic-Indic `٠-٩`), Bin (`0b`), Hex (`0x`). Underscores (`_`). Suffixes `غ`,`ط`,`طط`. | Implemented         | Baa does not explicitly support C-style octal literals (e.g., `012`). Arabic suffixes `غ`(U), `ط`(L), `طط`(LL) are tokenized. Interpretation by Parser/Semantics. |
+| Floating-Point            | Dec point (`.` or `٫`), Sci-notation (`e`/`E`; Arabic `أ` planned). Suffix `ح` (F) planned. Underscores. | Implemented (e/E) / Planned (`أ`, `ح`) | Arabic decimal `٫` supported. Arabic-Indic digits supported.                                                                                             |
+| Character (`'c'`, `L'c'`) | `'حرف'` (16-bit `wchar_t`). Standard escapes, `\uXXXX`. Baa-specific Arabic escapes (`\س` etc.) planned. | Implemented / Planned (Arabic Escapes) | Uses `\` as escape char.                                                                                                                                  |
+| String (`"s"`, `L"s"`)    | `"نص"`. Multiline `"""..."""`. Raw `خ"..."`. Standard escapes, `\uXXXX`. Arabic escapes planned.       | Implemented / Planned (Arabic Escapes) | Internally UTF-16LE after preprocessing.                                                                                                              |
+| Boolean (`true`, `false` C++) | `صحيح`, `خطأ`                                                                                   | Implemented         | Baa has `منطقي` type and these literals.                                                                                                                               |
+| Compound Literals (C99)   | `(اسم_النوع){قائمة_التهيئة}`                                                                      | Planned (Parser/AST) | e.g., `(عدد_صحيح[]){1,2,3}`.                                                                                                                            |
 
-### Control Flow
+### Control Flow Statements
 
-| C99 Feature | B (باء) Equivalent | Status      | Notes |
-|---------------|--------------------|-------------|-------|
-| `if`          | `إذا`             | Implemented | AST/Parsing exists. |
-| `else`        | `وإلا`            | Implemented | AST/Parsing exists. |
-| `while`       | `طالما`           | Implemented | AST/Parsing exists. |
-| `do`          | `افعل`            | Planned     | Keyword exists (`BAA_TOKEN_DO`), but parsing logic not implemented. |
-| `for`         | `لكل`             | Implemented | AST/Parsing exists (`BaaForStmt`). Supports C99-style declaration in init part (Planned). Separators are ';'. |
-| `switch`      | `اختر`            | Implemented | AST/Parsing exists (`BaaSwitchStmt`). |
-| `case`        | `حالة`            | Implemented | AST/Parsing exists (`BaaCaseStmt`). |
-| `break`       | `توقف`            | Implemented | Keyword exists (`BAA_TOKEN_BREAK`). AST/Parsing exists. Basic flow analysis check implemented. |
-| `continue`    | `أكمل`            | Implemented | Keyword exists (`BAA_TOKEN_CONTINUE`). AST/Parsing exists. Basic flow analysis check implemented. |
-| `return`      | `إرجع`            | Implemented | Keyword exists (`BAA_TOKEN_RETURN`). AST/Parsing exists. |
-| `goto`        | `اذهب`            | Planned     | Keyword not observed in lexer/parser implementation. |
+| C99 Feature  | B (باء) Equivalent    | Status (Lexer/PP) | Notes                                                                                                   |
+|----------------|-----------------------|-------------------|---------------------------------------------------------------------------------------------------------|
+| `if`           | `إذا`                | Implemented       | Parsing/AST/Semantics planned.                                                                            |
+| `else`         | `وإلا`               | Implemented       | Parsing/AST/Semantics planned.                                                                            |
+| `while`        | `طالما`              | Implemented       | Parsing/AST/Semantics planned.                                                                            |
+| `do ... while` | `افعل ... طالما`      | Implemented (Lexer `افعل`) / Planned (Parser/AST) | Keyword `افعل` tokenized.                                                                             |
+| `for`          | `لكل`                | Implemented       | C-style `for(init; cond; iter)`. Semicolons used. Parsing/AST/Semantics planned. Declaration in init planned. |
+| `switch`       | `اختر`               | Implemented       | Parsing/AST/Semantics planned.                                                                            |
+| `case`         | `حالة`               | Implemented       | Parsing/AST/Semantics planned.                                                                            |
+| `default`      | `افتراضي` (assumed)   | Planned (Lexer/Parser/AST) | Keyword `افتراضي` not yet in lexer; assumed for C parity.                                                 |
+| `break`        | `توقف`               | Implemented       | Parsing/AST/Semantics planned.                                                                            |
+| `continue`     | `أكمل`               | Implemented       | Parsing/AST/Semantics planned.                                                                            |
+| `return`       | `إرجع`               | Implemented       | Parsing/AST/Semantics planned.                                                                            |
+| `goto`         | `اذهب` (tentative)   | Planned (Lexer/Parser/AST) | Not yet in lexer.                                                                                       |
+| Labeled Stmts  | `معرف:` (tentative)   | Planned (Parser/AST) |                                                                                                         |
 
 ### Operators
 
-| C99 Feature | B (باء) Equivalent | Status      | Notes |
-|---------------|--------------------|-------------|-------|
-| Arithmetic    | Same symbols       | Implemented | +, -, *, /, %. Basic type validation exists. |
-| Comparison    | Same symbols       | Implemented | ==, !=, <, >, <=, >=. Basic type validation exists. |
-| Logical       | Same symbols       | Implemented | &&, ||, !. Basic type validation for `!` exists. `&&`/`||` need validation logic. |
-| Bitwise       | Same symbols       | Partial     | &, |, ^, <<, >>, ~. Keywords exist. Type validation logic missing. |
-| Assignment    | Same symbols       | Implemented | =. Basic type validation exists. |
-| Compound Assignment | Same symbols | Implemented | +=, -=, *=, /=, %=. AST/Parsing exists. Type validation logic missing. |
-| Increment/Decrement | Same symbols | Implemented | ++, --. AST/Parsing exists. Type validation logic missing. |
-| Address       | Same symbols       | Planned     | &, *. Requires pointer implementation. |
-| Member Access (direct) | `::`             | Planned     | C uses `.`, Baa uses `::` due to `.` as statement terminator. |
-| Member Access (pointer) | `->`             | Planned     | Same as C. |
-| Sizeof        | `حجم`             | Planned     | Keyword not observed in lexer/parser implementation. |
+(Baa uses standard C symbols for most operators)
 
-### Boolean Literals
+| C99 Category / Op | B (باء) Symbol / Keyword | Status (Lexer/Core) | Notes                                                               |
+|-------------------|--------------------------|---------------------|---------------------------------------------------------------------|
+| Postfix `++` `--` | `++` `--`                | Implemented         | Parsing/AST/Semantics planned.                                        |
+| Function Call `()`| `()`                     | Implemented         | Parsing/AST/Semantics planned.                                        |
+| Array Subscript`[]`| `[]`                     | Implemented         | Parsing/AST/Semantics planned.                                        |
+| Member `.` `->`   | `::` (direct), `->` (ptr)| Implemented (`->`) / Planned (`::`) | Baa uses `::` for direct struct/union member access.                |
+| Unary `++` `--`   | `++` `--`                | Implemented         | Prefix. Parsing/AST/Semantics planned.                               |
+| Unary `+` `-`     | `+` `-`                  | Implemented         | Parsing/AST/Semantics planned.                                        |
+| Unary `!` `~`     | `!` `~`                  | Implemented         | Logical NOT `!`, Bitwise NOT `~`. Parsing/AST/Semantics planned.      |
+| Unary `*` (deref) | `*`                      | Planned             | Requires pointer implementation.                                    |
+| Unary `&` (addr)  | `&`                      | Planned             | Requires pointer implementation.                                    |
+| `sizeof`          | `حجم`                    | Implemented (Lexer) / Planned (Semantic/CodeGen) |                                                     |
+| Cast `(type)`     | `(نوع)`                  | Planned (Parser/AST) |                                                                     |
+| Multiplicative    | `*` `/` `%`              | Implemented         | Parsing/AST/Semantics planned.                                        |
+| Additive          | `+` `-`                  | Implemented         | Parsing/AST/Semantics planned.                                        |
+| Bitwise Shift     | `<<` `>>`                | Implemented (PP) / Planned (Parser/AST) | In preprocessor expressions. Parsing for general code planned.   |
+| Relational        | `<` `>` `<=` `>=`        | Implemented         | Parsing/AST/Semantics planned.                                        |
+| Equality          | `==` `!=`                | Implemented         | Parsing/AST/Semantics planned.                                        |
+| Bitwise AND       | `&`                      | Implemented (PP) / Planned (Parser/AST) | In preprocessor expressions. Parsing for general code planned.   |
+| Bitwise XOR       | `^`                      | Implemented (PP) / Planned (Parser/AST) | In preprocessor expressions. Parsing for general code planned.   |
+| Bitwise OR        | `|`                      | Implemented (PP) / Planned (Parser/AST) | In preprocessor expressions. Parsing for general code planned.   |
+| Logical AND       | `&&`                     | Implemented         | Parsing/AST/Semantics planned.                                        |
+| Logical OR        | `||`                     | Implemented         | Parsing/AST/Semantics planned.                                        |
+| Conditional `?:`  | `?:`                     | Planned (Parser/AST) |                                                                     |
+| Assignment        | `=` `+=` `-=` etc.       | Implemented         | Parsing/AST/Semantics planned.                                        |
+| Comma `,`         | `,`                      | Implemented         | Parsing/AST/Semantics planned (e.g., in function calls, for loops).   |
 
-| C99 Feature | B (باء) Equivalent | Status      | Notes |
-|---------------|--------------------|-------------|-------|
-| `1` (typically) | `صحيح`          | Implemented | Boolean true literal (`true` is C99+). |
-| `0` (typically) | `خطأ`           | Implemented | Boolean false literal (`false` is C99+). |
+### Functions
 
-### Function Parameters
-
-| C99 Feature | B (باء) Extension | Status      | Notes |
-|---------------|-------------------|-------------|-------|
-| Basic parameters | Basic parameters | Implemented | Standard function parameters. |
-| Default values | Optional parameters | Planned     | AST (`BaaParameter`) supports feature, but parser implementation is missing. |
-| Variadic functions | Rest parameters | Planned     | AST (`BaaParameter`) supports feature, but parser implementation is missing. |
-| - | Named arguments | Planned     | AST (`BaaCallExpr`) supports feature, but parser implementation is missing. |
-| - | Method distinction | Partial?    | AST (`BaaFunction`) supports `is_method`. Usage/semantics unclear. Parser does not set this. |
+| C99 Feature         | B (باء) Equivalent        | Status                      | Notes                                                                    |
+|-----------------------|---------------------------|-----------------------------|--------------------------------------------------------------------------|
+| Declaration/Definition| C-style: `type name(params)` | Planned (Parser/AST)        | `دالة` keyword removed from language spec.                               |
+| `inline` specifier  | `مضمن`                    | Implemented (Lexer) / Planned (Semantic/CodeGen) | Hint to compiler.                                                        |
+| Variadic Functions (`...`) | `...` (in C style decl) | Planned (Parser/AST/Codegen) | Standard C variadic functions. Not to be confused with preprocessor variadic macros. |
 
 ### Preprocessor
 
-| C99 Feature | B (باء) Equivalent | Status      | Notes |
-|---------------|--------------------|-------------|-------|
-| `#include`    | `#تضمين`          | Implemented | Handled by the external `baa_preprocess` function. |
-| `#define`     | `#تعريف`          | Implemented | Supports object-like, function-like macros (with arguments), stringification (`#`), and token pasting (`##`). Handled by `baa_preprocess`. |
-| `#elif`       | `#وإلا_إذا`        | Implemented | C99 standard directive. Handled by `baa_preprocess`. |
-| `#ifdef`      | `#إذا_عرف`        | Implemented | Handled by `baa_preprocess`. |
-| `#ifndef`     | `#إذا_لم_يعرف`    | Implemented | Handled by `baa_preprocess`. |
-| `#else`       | `#إلا`            | Implemented | Handled by `baa_preprocess`. |
-| `#endif`      | `#نهاية_إذا`      | Implemented | Handled by `baa_preprocess`. |
-| `#undef`      | `#الغاء_تعريف`    | Implemented | Handled by `baa_preprocess`. |
-| `defined` operator | `معرف` operator   | Implemented | Baa uses `معرف` for the `defined` operator. |
-| `__FILE__`           | `__الملف__`        | Implemented | Expands to current file name. |
-| `__LINE__`           | `__السطر__`        | Implemented | Expands to current line number. |
-| `__DATE__`           | `__التاريخ__`      | Implemented | Expands to preprocessing date. |
-| `__TIME__`           | `__الوقت__`        | Implemented | Expands to preprocessing time. |
-| `__STDC_VERSION__`   | `__إصدار_المعيار_باء__` | Implemented    | Baa defines `__إصدار_المعيار_باء__` expanding to `10010L`. |
-| `__func__`           | `__الدالة__`       | Implemented (as placeholder)     | C99 predefined identifier. Baa equivalent `__الدالة__` expands to `L"__BAA_FUNCTION_PLACEHOLDER__"` in preprocessor. |
-| Variadic Macros (`...`, `__VA_ARGS__`) | `وسائط_إضافية`, `__وسائط_متغيرة__` | Implemented | Baa uses `وسائط_إضافية` for `...` and `__وسائط_متغيرة__` for `__VA_ARGS__`. |
-| `#error`             | `#خطأ`             | Planned     | Baa equivalent for `#error message`. |
-| `#warning`           | `#تحذير`           | Planned     | Baa equivalent for `#warning message`. |
-| `#line`              | `#سطر`             | Planned     | Baa equivalent for `#line number "filename"`. |
-| `_Pragma` operator   | `أمر_براغما`       | Planned     | Baa equivalent for `_Pragma("directive")`. |
-| `#pragma`            | `#براغما`           | Planned     | Baa equivalent for `#pragma directive`. |
-
-### Standard Library
-
-**(Note: Status reflects availability of Baa function names/bindings, not necessarily full C99 implementation completeness/correctness)**
-
-| C99 Feature | B (باء) Equivalent | Status   | Notes |
-|---------------|--------------------|----------|-------|
-| `printf`      | `اطبع`            | Unknown  | Baa function likely exists, implementation details unknown. |
-| `scanf`       | `اقرأ`            | Unknown  | Baa function likely exists, implementation details unknown. |
-| `fopen`       | `افتح_ملف`        | Unknown  | Baa function likely exists, implementation details unknown. |
-| `fclose`      | `اغلق_ملف`        | Unknown  | Baa function likely exists, implementation details unknown. |
-| `malloc`      | `حجز_ذاكرة`       | Unknown  | Baa function likely exists (maybe `baa_malloc` internally), implementation details unknown. |
-| `free`        | `حرر_ذاكرة`       | Unknown  | Baa function likely exists (maybe `baa_free` internally), implementation details unknown. |
-| `strcpy`      | `نسخ_نص`          | Unknown  | Baa function likely exists, implementation details unknown. |
-| `strlen`      | `طول_نص`          | Unknown  | Baa function likely exists, implementation details unknown. |
-| `strcmp`      | `مقارنة_نص`       | Unknown  | Baa function likely exists, implementation details unknown. |
-
-## Implementation Roadmap
-
-**(This section has been removed as it was inconsistent with detailed component status. Please refer to `docs/roadmap.md` and component-specific roadmaps like `docs/LEXER_ROADMAP.md`, `docs/PARSER_ROADMAP.md`, etc. for detailed status and future plans.)**
-
-## Extensions Beyond C99
-
-### Unicode Support
-
-- 16-bit character type (`wchar_t`) - `Implemented`
-- UTF-16LE string literals - `Implemented` (Lexer assumes UTF-16LE input)
-- Arabic identifier support - `Implemented`
-- Bidirectional text handling - `N/A` (Considered an editor/terminal concern)
-
-### Error Messages
-
-- Arabic language error messages - `Partial` (Number parsing only; general errors planned)
-- Enhanced error recovery - `Planned` (Basic parser synchronization planned)
-- Detailed diagnostic information - `Planned`
-- Context-aware suggestions - `Planned`
-
-### Development Tools
-
-- Interactive debugger - `Planned`
-- Performance profiler - `Planned`
-- Memory analyzer - `Planned`
-- Documentation generator - `Planned`
-
-### Modern Features
-
-- Source code formatting - `Planned`
-- Static analysis - `Planned`
-- Code completion - `Planned`
-- Refactoring tools - `Planned`
-
-## Compatibility Notes
-
-### Source Code
-
-- C99 source code may require syntax changes (e.g., keywords to Arabic, statement terminator '.'), type adjustments (if Baa's type sizes/features differ), and UTF-16LE encoding conversion for Baa compilation.
-- Arabic keywords can be used alongside English identifiers - `Implemented` (Lexer/Parser support this).
-- UTF-16LE encoding required for source files - `Implemented` (Lexer assumes this).
-- Bidirectional text support in string literals - `Implemented` (Supported via `wchar_t`).
-
-### Binary Compatibility
-
-- Generated object files are compatible with C linkers - `N/A` (Code generation not implemented).
-- Standard C calling convention - `N/A` (Code generation not implemented).
-- Standard C ABI compliance - `N/A` (Code generation not implemented).
-- Platform-specific alignment rules - `N/A` (Code generation not implemented).
-
-### Standard Library
-
-- K&R C standard library functions available - `Unknown` / `Planned`.
-- Arabic function names provided as aliases - `Unknown` / `Planned`.
-- Extended Unicode support functions - `Unknown` / `Planned`.
-- Additional helper functions for Arabic text - `Unknown` / `Planned`.
-
-### Tool Integration
-
-- Compatible with standard C debuggers - `N/A` (Code generation not implemented).
-- Works with common build systems - `Implemented` (CMake).
-- Supports standard profiling tools - `N/A` (Code generation not implemented).
-- Integrates with popular IDEs - `Planned`.
-
-## Syntax Comparison (مقارنة التركيب)
-
-### Basic Program Structure
-
-```c
-// C Version
-int main() {
-    printf("Hello, World!\n");
-    return 0;
-}
-```
-
-```baa
-// Baa Version
-دالة رئيسية() {
-    اطبع("مرحباً بالعالم!").
-    إرجع 0.
-}
-```
-
-### Variable Declaration
-
-```c
-// C Version
-int count = 0;
-float price = 10.5;
-char letter = 'A';
-```
-
-```baa
-// Baa Version
-عدد_صحيح عداد = 0.
-عدد_حقيقي سعر = 10.5.
-حرف حرف = 'أ'.
-```
-
-### Control Structures
-
-```c
-// C Version
-if (age >= 18) {
-    printf("Adult\n");
-} else {
-    printf("Minor\n");
-}
-
-while (count < 10) {
-    count++;
-}
-```
-
-```baa
-// Baa Version
-إذا (عمر >= 18) {
-    اطبع("بالغ").
-} وإلا {
-    اطبع("قاصر").
-}
-
-طالما (عداد < 10) {
-    عداد++.
-}
-```
-
-## Feature Comparison (مقارنة الميزات)
-
-### 1. Types (الأنواع)
-
-| C Type | Baa Type | Size | Notes |
-|--------|----------|------|-------|
-| int | عدد_صحيح | 32-bit | Same range |
-| float | عدد_حقيقي | 32-bit | Same precision |
-| char | حرف | 16-bit | UTF-16LE character/string in Baa |
-| void | فراغ | - | Same usage |
-| struct | بنية | varies | Same layout |
-| union | اتحاد | varies | Same usage |
-
-### 2. Operators (العمليات)
-
-| Category | C | Baa | Notes |
-|----------|---|-----|-------|
-| Arithmetic | +, -, *, /, % | جمع, طرح, ضرب, قسمة, باقي | Same precedence |
-| Comparison | ==, !=, <, > | يساوي, لا_يساوي, أصغر_من, أكبر_من | Same behavior |
-| Logical | &&, \|\|, ! | و, أو, ليس | Same rules |
-| Bitwise | &, \|, ^, ~, <<, >> | Same | Not localized |
-
-### 3. Keywords (الكلمات المفتاحية)
-
-| C | Baa | Notes |
-|---|-----|-------|
-| if | إذا | Same semantics |
-| else | وإلا | Same usage |
-| while | طالما | Same behavior |
-| for | لكل | Same structure |
-| return | إرجع | Same purpose |
-| struct | بنية | Same memory layout |
-| typedef | نوع_مستخدم | Same functionality |
-
-## Memory Model (نموذج الذاكرة)
-
-- Same stack and heap organization
-- Identical pointer arithmetic
-- Compatible struct padding
-- Similar alignment rules
-
-## Standard Library (المكتبة القياسية)
-
-| C Function | Baa Function | Purpose |
-|------------|-------------|----------|
-| printf | اطبع | Output text |
-| scanf | اقرأ | Input text |
-| malloc | احجز | Allocate memory |
-| free | حرر | Free memory |
-| strlen | طول_نص | String length |
-| strcpy | انسخ_نص | String copy |
-
-## Compilation Process (عملية الترجمة)
-
-1. **Preprocessing**
-   - C: #include, #define
-   - Baa: تضمين#, تعريف#
-
-2. **Compilation**
-   - Both generate similar intermediate code
-   - Baa adds Arabic symbol handling
-
-3. **Linking**
-   - Compatible object file format
-   - Same linking process
-
-## Key Differences (الفروق الرئيسية)
-
-### 1. Text Handling
-
-- Baa uses UTF-8 by default
-- Better support for Arabic text
-- RTL text rendering
-- Arabic string literals
-
-### 2. Error Messages
-
-- Baa provides Arabic error messages
-- More detailed error descriptions
-- Cultural context in messages
-- Bilingual support
-
-### 3. Development Tools
-
-- Arabic-aware debugger
-- RTL-compatible editors
-- Arabic documentation
-- Localized tooling
-
-### 4. Extensions
-
-- Arabic identifier support
-- RTL code formatting
-- Arabic documentation comments
-- Cultural adaptations
-
-## Migration Guide (دليل الترحيل)
-
-### From C to Baa
-
-1. Convert keywords to Arabic
-2. Update type names
-3. Translate identifiers
-4. Adjust string encoding
-5. Update comments
-
-### From Baa to C
-
-1. Convert keywords to English
-2. Restore C type names
-3. Transliterate identifiers
-4. Convert UTF-8 strings
-5. Translate comments
-
-## Best Practices (أفضل الممارسات)
-
-### 1. Code Style
-
-- Consistent language choice
-- Clear naming conventions
-- Proper text direction
-- Cultural considerations
-
-### 2. Interoperability
-
-- Use compatible types
-- Maintain C ABI
-- Document translations
-- Handle encodings
-
-## Version Compatibility (توافق الإصدارات)
-
-- Version 0.1.7: Basic C compatibility
-- Version 0.1.8: Enhanced features
-  - Better error messages
-  - Improved type system
-  - Extended standard library
-  - More Arabic keywords
+Baa's preprocessor aims for C99 compliance with Arabic keywords.
+
+| C99 Feature           | B (باء) Equivalent             | Status (Preprocessor)       | Notes                                                                               |
+|-----------------------|--------------------------------|-----------------------------|-------------------------------------------------------------------------------------|
+| `#include`            | `#تضمين`                       | Implemented                 |                                                                                     |
+| `#define` (object-like) | `#تعريف`                       | Implemented                 |                                                                                     |
+| `#define` (func-like)   | `#تعريف(params)`               | Implemented                 |                                                                                     |
+| `#undef`              | `#الغاء_تعريف`                 | Implemented                 |                                                                                     |
+| `#ifdef`              | `#إذا_عرف`                     | Implemented                 | Uses `معرف NAME`.                                                                    |
+| `#ifndef`             | `#إذا_لم_يعرف`                  | Implemented                 | Uses `!معرف NAME`.                                                                   |
+| `#if`                 | `#إذا`                         | Implemented                 | Evaluates constant integer expressions. Undefined macros are 0.                       |
+| `#elif`               | `#وإلا_إذا`                     | Implemented                 |                                                                                     |
+| `#else`               | `#إلا`                         | Implemented                 |                                                                                     |
+| `#endif`              | `#نهاية_إذا`                   | Implemented                 |                                                                                     |
+| `defined` operator    | `معرف` operator                | Implemented                 | `معرف MACRO` or `معرف(MACRO)`.                                                       |
+| `#` (stringification) | `#`                            | Implemented                 |                                                                                     |
+| `##` (token pasting)  | `##`                           | Implemented                 |                                                                                     |
+| `__FILE__`            | `__الملف__`                   | Implemented                 |                                                                                     |
+| `__LINE__`            | `__السطر__`                   | Implemented                 | Expands to integer.                                                                 |
+| `__DATE__`            | `__التاريخ__`                 | Implemented                 |                                                                                     |
+| `__TIME__`            | `__الوقت__`                   | Implemented                 |                                                                                     |
+| `__func__` (C99)      | `__الدالة__`                  | Implemented (PP Placeholder)| Preprocessor expands to placeholder; final value by later stages.                   |
+| `__STDC_VERSION__`    | `__إصدار_المعيار_باء__`        | Implemented                 | e.g., `10150L`.                                                                     |
+| Variadic Macros       | `وسائط_إضافية`, `__وسائط_متغيرة__` | Implemented                 | `...` becomes `وسائط_إضافية`, `__VA_ARGS__` becomes `__وسائط_متغيرة__`.                |
+| `#error`              | `#خطأ`                         | Implemented                 |                                                                                     |
+| `#warning`            | `#تحذير`                       | Implemented                 |                                                                                     |
+| `#line`               | `#سطر`                         | Planned                     |                                                                                     |
+| `_Pragma` operator    | `أمر_براغما`                   | Planned                     |                                                                                     |
+| `#pragma`             | `#براغما`                      | Planned                     | e.g., `#براغما مرة_واحدة` for `#pragma once`.                                         |
+
+### Miscellaneous C99 Features
+
+| C99 Feature                                | B (باء) Equivalent / Status                                   | Notes                                                                 |
+|--------------------------------------------|---------------------------------------------------------------|-----------------------------------------------------------------------|
+| Variable length arrays (VLAs)              | Planned (Future)                                              | Stack-allocated arrays whose size is determined at runtime.           |
+| Flexible array members (in structs)        | Planned (Parser/AST)                                          | e.g., `type member[];` as last member of a struct.                    |
+| Designated initializers                    | Planned (Parser/AST)                                          | For arrays `[index] = value`, for structs/unions `::member = value` (using `::` instead of `.`) |
+| Mixing declarations and code               | Planned (Parser/AST)                                          | Allowed in C99 within blocks.                                         |
+| `//` comments                              | Implemented (Lexer/PP)                                        |                                                                       |
+| Universal Character Names (`\uXXXX`, `\UXXXXXXXX`) | Implemented (Lexer `\uXXXX`) / Planned (Lexer `\UXXXXXXXX`) | Baa also plans Arabic-specific escapes like `\يXXXX`.                  |
+| `snprintf`, `vsnprintf` family             | Standard Library: `اطبع_نص_مُنسق_مُقيد` (tentative)            | Planned (Standard Library)                                            |
+| `<stdbool.h>`, `<stdint.h>`, `<inttypes.h>`| Baa types map to these concepts. Specific headers not directly included by user. | Implemented (Core Types)                                             |
+| `<complex.h>`, `<fenv.h>`, `<tgmath.h>`    | Planned (Future - Standard Library Extensions)                | Low priority.                                                         |
+
+## Key Syntactic Differences from C99
+
+* **Statement Terminator:** Baa uses `.` (dot) instead of C's `;`.
+* **Keywords:** Baa uses Arabic keywords.
+* **Literals:** Baa extends support for Arabic-Indic digits, Arabic decimal separator (`٫`), planned Arabic exponent marker (`أ`), and Arabic literal suffixes (`غ`, `ط`, `طط`, `ح`). Planned Arabic-specific escape sequences.
+* **Struct/Union Member Access (Direct):** Baa uses `::` for direct member access (e.g., `my_struct::member`) because `.` is the statement terminator. Pointer member access remains `->`.
+* **Function Declaration Keywords:** Baa has removed `دالة` (function) and `متغير` (variable) as explicit declaration keywords, favoring C-style declarations (`type name(...){}`).
+
+## Standard Library
+
+Baa plans to provide a standard library with Arabic function names that correspond to common C standard library functions (e.g., `اطبع` for `printf`). The extent and direct C99 compatibility of this library is part of ongoing development.
+
+*This comparison is based on the Baa language specification documents and current implementation status. It will evolve as the Baa compiler develops.*

--- a/docs/project_structure.md
+++ b/docs/project_structure.md
@@ -1,130 +1,180 @@
 # هيكل مشروع لغة باء (Baa Project Structure)
 
+## نظرة عامة (Overview)
+
+يوضح هذا المستند الهيكل التنظيمي لمجلدات وملفات مشروع مترجم لغة باء. يهدف هذا الهيكل إلى تحقيق الوضوح، الفصل بين الاهتمامات، وتسهيل عملية التطوير والصيانة.
+
 ## المجلدات الرئيسية (Main Directories)
 
 ```
 baa/
-├── include/                 # ملفات الرأس العامة - Public headers
-│   └── baa/
-│       ├── ast/           # بنية الشجرة النحوية
-│       │   ├── expressions.h  # تعريفات التعبيرات
-│       │   ├── statements.h   # تعريفات الجمل
-│       │   ├── function.h     # تعريفات الدوال
-│       │   └── ast.h         # تعريفات عامة
-│       ├── lexer/         # المحلل اللفظي
-│       │   ├── lexer.h            # الواجهة الرئيسية للمحلل اللفظي (Public API)
-│       │   ├── token_scanners.h   # تعريفات دوال مسح الرموز (Token scanning functions)
-│       │   └── lexer_char_utils.h # أدوات مساعدة للتعامل مع الحروف (Character utilities)
-│       ├── parser/        # المحلل النحوي
-│       │   ├── parser.h      # واجهة المحلل النحوي
-│       │   ├── expression_parser.h # محلل التعبيرات
-│       │   └── statement_parser.h  # محلل الجمل
-│       ├── preprocessor/  # المعالج المسبق
-│       │   └── preprocessor.h # واجهة المعالج المسبق
-│       ├── operators.h     # العمليات والأسبقية
-│       └── types.h         # نظام الأنواع
-│       └── compiler.h      # واجهة المترجم الرئيسي
+├── .editorconfig            # إعدادات المحرر لتوحيد نمط الشيفرة
+├── .gitignore               # الملفات والمجلدات التي يتجاهلها Git
+├── CHANGELOG.md             # سجل التغييرات والإصدارات
+├── CMakeLists.txt           # ملف بناء المشروع الرئيسي (CMake)
+├── LICENSE                  # رخصة المشروع (MIT)
+├── README.md                # معلومات عامة عن المشروع ومقدمة
 │
-├── src/                    # الشيفرة المصدرية - Source code
-│   ├── ast/               # تنفيذ الشجرة النحوية
-│   │   ├── expressions.c  # تنفيذ تعبيرات الشجرة
-│   │   ├── statements.c   # تنفيذ جمل الشجرة
-│   │   ├── function.c     # تنفيذ دوال الشجرة
-│   │   └── ast.c         # تنفيذ عام للشجرة
-│   ├── lexer/             # تنفيذ المحلل اللفظي
-│   │   ├── lexer.c              # المنطق الرئيسي للمحلل اللفظي (Core lexer logic)
-│   │   ├── token_scanners.c     # تنفيذ دوال مسح الرموز (Implementation of token scanners)
-│   │   ├── lexer_char_utils.c   # تنفيذ أدوات الحروف (Implementation of char utilities)
-│   │   └── number_parser.c      # محلل الأرقام (لتحويل النص إلى قيمة عددية - Number string to value parser)
-│   ├── parser/            # تنفيذ المحلل النحوي
-│   │   ├── parser.c      # تنفيذ رئيسي
-│   │   ├── expression_parser.c # تنفيذ معالجة التعبيرات
-│   │   └── statement_parser.c  # تنفيذ معالجة الجمل
-│   ├── preprocessor/      # تنفيذ المعالج المسبق
-│   │   └── preprocessor.c  # تنفيذ رئيسي للمعالج
-│   ├── operators/         # تنفيذ العمليات
-│   └── types/             # تنفيذ نظام الأنواع
-│   ├── compiler.c         # منطق الترجمة الرئيسي
-│   └── main.c             # نقطة الدخول الرئيسية للتطبيق
+├── cmake/                   # وحدات CMake المخصصة (Custom CMake modules)
+│   └── BaaCompilerSettings.cmake # إعدادات المترجم المشتركة (مثال)
 │
-├── tests/                  # الاختبارات - Tests
-│   ├── unit/              # اختبارات الوحدات
-│   │   ├── ast/          # اختبارات الشجرة النحوية
-│   │   ├── lexer/        # اختبارات المحلل اللفظي
-│   │   ├── operators/    # اختبارات العمليات
-│   │   └── parser/       # اختبارات المحلل النحوي
+├── docs/                    # مجلد التوثيق (Documentation)
+│   ├── AST.md               # (تصميم جديد) وثيقة تصميم شجرة النحو المجردة
+│   ├── AST_ROADMAP.md       # (تصميم جديد) خارطة طريق تنفيذ شجرة النحو المجردة
+│   ├── CMAKE_ROADMAP.md     # خارطة طريق تطوير نظام البناء CMake
+│   ├── LEXER_ROADMAP.md     # خارطة طريق تطوير المحلل اللفظي
+│   ├── LLVM_CODEGEN.md      # وثيقة تصميم توليد الشيفرة باستخدام LLVM
+│   ├── LLVM_CODEGEN_ROADMAP.md # خارطة طريق تنفيذ توليد الشيفرة LLVM
+│   ├── PARSER.md            # (تصميم جديد) وثيقة تصميم المحلل النحوي
+│   ├── PARSER_ROADMAP.md    # (تصميم جديد) خارطة طريق تنفيذ المحلل النحوي
+│   ├── PREPROCESSOR_ROADMAP.md # خارطة طريق تطوير المعالج المسبق
+│   ├── SEMANTIC_ANALYSIS.md # (مخطط) وثيقة تصميم التحليل الدلالي
+│   ├── SEMANTIC_ANALYSIS_ROADMAP.md # (مخطط) خارطة طريق التحليل الدلالي
+│   ├── arabic_support.md    # تفاصيل دعم اللغة العربية
+│   ├── architecture.md      # نظرة عامة على معمارية المترجم
+│   ├── c_comparison.md      # مقارنة مع لغة C
+│   ├── development.md       # دليل تطوير المشروع
+│   ├── language.md          # مواصفات لغة باء
+│   ├── lexer.md             # وثائق المحلل اللفظي
+│   ├── preprocessor.md      # وثائق المعالج المسبق
+│   ├── project_structure.md # هذا الملف (هيكل المشروع)
+│   └── roadmap.md           # خارطة الطريق العامة للمشروع
+│
+├── include/                 # ملفات الرأس العامة للمكتبات (Public headers for libraries)
+│   └── baa/                 # مساحة الاسم الرئيسية لمكتبات باء
+│       ├── analysis/        # واجهات التحليل الدلالي وتحليل التدفق
+│       │   ├── flow_analysis.h
+│       │   └── flow_errors.h
+│       ├── codegen/         # واجهات توليد الشيفرة
+│       │   ├── codegen.h
+│       │   └── llvm_codegen.h
+│       ├── compiler.h       # واجهة المترجم الرئيسية (الدالة compile_baa_file)
+│       ├── diagnostics/     # (مخطط، يعتمد على AST) واجهات نظام التشخيصات والأخطاء
+│       │   └── diagnostics.h
+│       ├── lexer/           # واجهات المحلل اللفظي
+│       │   ├── lexer.h              # الواجهة العامة للمحلل اللفظي
+│       │   ├── lexer_char_utils.h   # أدوات مساعدة للحروف (عامة إذا احتاجتها مكونات أخرى)
+│       │   ├── lexer_internal.h     # (عادة لا يكون هنا، بل في src/lexer) تعريفات داخلية إذا كانت مشتركة بشكل استثنائي
+│       │   └── token_scanners.h   # (عادة لا يكون هنا، بل في src/lexer)
+│       ├── operators/       # واجهة نظام العمليات
+│       │   └── operators.h
+│       ├── preprocessor/    # واجهة المعالج المسبق
+│       │   └── preprocessor.h
+│       ├── types/           # واجهة نظام الأنواع
+│       │   └── types.h
+│       └── utils/           # واجهات الأدوات المساعدة
+│           ├── errors.h
+│           └── utils.h
+│
+├── src/                     # الشيفرة المصدرية للمكتبات والمترجم (Source code)
+│   ├── CMakeLists.txt       # يضيف المجلدات الفرعية للمكونات كمكتبات
 │   │
-│   └── integration/       # اختبارات التكامل
-│       └── examples/      # أمثلة للاختبار
-│
-├── docs/                   # التوثيق - Documentation
-│   ├── PREPROCESSOR_ROADMAP.md # خارطة طريق المعالج المسبق
-│   ├── ar/               # التوثيق بالعربية
-│   │   ├── grammar.md    # قواعد اللغة
-│   │   └── tutorial.md   # دليل التعلم
+│   ├── analysis/            # تنفيذ التحليل الدلالي وتحليل التدفق
+│   │   ├── CMakeLists.txt
+│   │   ├── flow_analysis.c
+│   │   └── flow_errors.c
 │   │
-│   └── en/               # English documentation
-│       ├── grammar.md    # Language grammar
-│       └── tutorial.md   # Tutorial
+│   ├── codegen/             # تنفيذ توليد الشيفرة
+│   │   ├── CMakeLists.txt
+│   │   ├── codegen.c        # المنطق العام لتوليد الشيفرة
+│   │   ├── llvm_codegen.c   # تنفيذ توليد الشيفرة باستخدام LLVM (إذا كان LLVM مفعلاً)
+│   │   └── llvm_stub.c      # تنفيذ بديل (stub) عند تعطيل LLVM
+│   │
+│   ├── compiler.c           # منطق الترجمة الرئيسي (جزء من مكتبة baa_compiler_lib)
+│   │
+│   ├── lexer/               # تنفيذ المحلل اللفظي
+│   │   ├── CMakeLists.txt
+│   │   ├── lexer.c              # المنطق الرئيسي للمحلل اللفظي
+│   │   ├── lexer_char_utils.c   # تنفيذ أدوات الحروف
+│   │   ├── number_parser.c      # محلل الأرقام (تحويل النص إلى قيمة)
+│   │   └── token_scanners.c     # دوال مسح أنواع الرموز المختلفة
+│   │
+│   ├── main.c               # نقطة الدخول الرئيسية لبرنامج المترجم `baa`
+│   │
+│   ├── operators/           # تنفيذ نظام العمليات
+│   │   ├── CMakeLists.txt
+│   │   └── operators.c
+│   │
+│   ├── preprocessor/        # تنفيذ المعالج المسبق
+│   │   ├── CMakeLists.txt
+│   │   ├── preprocessor.c
+│   │   ├── preprocessor_conditionals.c
+│   │   ├── preprocessor_core.c
+│   │   ├── preprocessor_directives.c
+│   │   ├── preprocessor_expansion.c
+│   │   ├── preprocessor_expr_eval.c
+│   │   ├── preprocessor_internal.h    # تعريفات داخلية مشتركة للمعالج المسبق
+│   │   ├── preprocessor_line_processing.c
+│   │   ├── preprocessor_macros.c
+│   │   └── preprocessor_utils.c
+│   │
+│   ├── types/               # تنفيذ نظام الأنواع
+│   │   ├── CMakeLists.txt
+│   │   └── types.c
+│   │
+│   └── utils/               # تنفيذ الأدوات المساعدة
+│       ├── CMakeLists.txt
+│       └── utils.c
 │
-├── examples/               # أمثلة - Examples
-│   ├── basic/            # أمثلة أساسية
-│   └── advanced/         # أمثلة متقدمة
+├── tests/                   # الاختبارات (Unit and Integration Tests)
+│   ├── CMakeLists.txt       # إعداد بيئة الاختبارات
+│   │
+│   ├── framework/           # إطار عمل بسيط للاختبارات
+│   │   ├── test_framework.c
+│   │   └── test_framework.h
+│   │
+│   ├── codegen_tests/       # اختبارات خاصة بتوليد الشيفرة (حالياً قد تعتمد على AST القديم)
+│   │   ├── CMakeLists.txt
+│   │   ├── llvm_codegen_test.c # (قد يحتاج لتحديث أو تعطيل مؤقت)
+│   │   ├── llvm_test.c         # (قد يحتاج لتحديث أو تعطيل مؤقت)
+│   │   └── test_codegen.c      # (قد يحتاج لتحديث أو تعطيل مؤقت)
+│   │
+│   ├── integration/         # اختبارات التكامل (مخطط لها)
+│   │   └── CMakeLists.txt
+│   │
+│   ├── resources/           # ملفات الإدخال للاختبارات
+│   │   ├── lexer_test_cases/
+│   │   │   └── lexer_test_suite.baa
+│   │   └── preprocessor_test_cases/
+│   │       ├── include_test_header.baa
+│   │       ├── nested_include.baa
+│   │       └── preprocessor_test_all.baa
+│   │
+│   └── unit/                # اختبارات الوحدات لكل مكون
+│       ├── CMakeLists.txt     # يضيف مجلدات اختبارات الوحدات الفرعية
+│       ├── core/              # اختبارات المكونات الأساسية (الأنواع، العمليات)
+│       │   ├── CMakeLists.txt
+│       │   ├── test_operators.c # (قد يعتمد جزئيًا على AST/Parser القديم)
+│       │   └── test_types.c
+│       ├── lexer/
+│       │   ├── CMakeLists.txt
+│       │   └── ... (ملفات اختبار المحلل اللفظي)
+│       ├── preprocessor/
+│       │   ├── CMakeLists.txt
+│       │   └── test_preprocessor.c
+│       └── utils/
+│           ├── CMakeLists.txt
+│           └── test_utils.c
 │
-└── tools/                 # الأدوات المساعدة - Tools
-    ├── formatter/        # منسق الشيفرة
-    └── debugger/         # أداة التنقيح
+└── tools/                   # أدوات مساعدة للمطورين أو المستخدمين
+    ├── baa_lexer_tester.c       # أداة اختبار المحلل اللفظي
+    ├── baa_parser_tester.c      # (مخطط) أداة اختبار المحلل النحوي (تعتمد على المحلل الجديد)
+    └── baa_preprocessor_tester.c # أداة اختبار المعالج المسبق
 ```
 
-## ملفات المشروع الرئيسية (Main Project Files)
+## ملاحظات على الهيكل (Notes on Structure)
 
-```
-baa/
-├── CMakeLists.txt         # ملف بناء المشروع الرئيسي
-├── README.md              # معلومات المشروع
-├── CHANGELOG.md           # سجل التغييرات
-├── LICENSE                # رخصة المشروع
-└── .editorconfig         # إعدادات المحرر
-```
+* **`include/baa/`**: يحتوي على ملفات الرأس العامة (`.h`) التي تشكل الواجهة البرمجية (API) لكل مكتبة من مكونات المترجم. يجب أن تكون هذه الملفات مستقلة قدر الإمكان ولا تكشف التفاصيل الداخلية للتنفيذ.
+* **`src/<component>/`**: كل مكون رئيسي للمترجم (مثل `lexer`, `preprocessor`, `types`) له مجلده الخاص داخل `src/`.
+  * **`src/<component>/CMakeLists.txt`**: يعرف كيفية بناء المكتبة الثابتة (static library) الخاصة بالمكون (مثلاً `baa_lexer`, `baa_utils`).
+  * **`src/<component>/*.c`**: ملفات الشيفرة المصدرية لتنفيذ المكون.
+  * **`src/<component>/*_internal.h` (مثال: `preprocessor_internal.h`)**: ملفات رأس داخلية تستخدم لمشاركة التعريفات والدوال بين ملفات `.c` المختلفة *داخل نفس المكون فقط*. لا يجب تضمينها من خارج مجلد المكون.
+* **`src/compiler.c`**: يحتوي على المنطق الرئيسي لتنسيق عملية الترجمة (استدعاء المعالج المسبق، المحلل اللفظي، إلخ). يتم بناؤه الآن كجزء من مكتبة `baa_compiler_lib`.
+* **`src/main.c`**: نقطة الدخول لبرنامج `baa` القابل للتنفيذ. يستدعي بشكل أساسي الدوال من `baa_compiler_lib`.
+* **Parser & AST**: نظرًا لأنهما قيد إعادة التصميم، فإن ملفاتهما المحددة في `include/baa/ast`, `include/baa/parser`, `src/ast`, `src/parser` قد تكون بسيطة جدًا أو غير موجودة حاليًا حتى يكتمل التصميم الجديد.
+* **CMake Build System**:
+  * **Root `CMakeLists.txt`**: يدير المشروع بشكل عام، يحدد الخيارات، يجد الحزم (مثل LLVM)، ويضيف المجلدات الفرعية الرئيسية (`src`, `tests`, `tools`).
+  * **`cmake/BaaCompilerSettings.cmake`**: وحدة CMake مخصصة لتحديد إعدادات المترجم المشتركة (مثل تعريفات `UNICODE`) عبر مكتبة واجهة `BaaCommonSettings`.
+  * **Target-Centric Approach**: يتم تطبيق خصائص البناء (تعريفات، مسارات تضمين، روابط) على الأهداف المحددة (المكتبات والبرامج التنفيذية) بدلاً من استخدام أوامر عامة.
 
-## تنظيم الشيفرة (Code Organization)
-
-### المكتبات (Libraries)
-- `libbaa_ast`: مكتبة الشجرة النحوية - تتضمن كل أنواع التعبيرات والجمل والوظائف المعززة لمعالم الدوال
-- `libbaa_lexer`: مكتبة المحلل اللفظي - تتضمن دعم القيم المنطقية والعمليات المركبة والتعليقات
-- `libbaa_preprocessor`: مكتبة المعالج المسبق - تدعم معالجة التوجيهات (#تضمين، #تعريف)
-- `libbaa_operators`: مكتبة العمليات - تتضمن الزيادة/النقصان وعمليات التعيين المركبة
-- `libbaa_parser`: مكتبة المحلل النحوي - مبنية على طريقة النزول المتكرر وتدعم كل أنواع التعبيرات
-- `libbaa_types`: مكتبة الأنواع - تتضمن النوع المنطقي ودعم المصفوفات
-
-### الاختبارات (Tests)
-- اختبارات الوحدات لكل مكتبة
-- اختبارات التكامل للنظام كامل
-- اختبارات الأداء
-
-### التوثيق (Documentation)
-- توثيق API بالعربية والإنجليزية
-- أمثلة مع الشرح
-- دليل المساهمة في المشروع
-
-## نمط التسمية (Naming Conventions)
-
-### الملفات (Files)
-- ملفات المصدر: `.c`
-- ملفات الرأس: `.h`
-- ملفات باء: `.ب`
-- ملفات الاختبار: `_test.c`
-
-### التسمية في الشيفرة (Code Naming)
-- الدوال: `baa_*`
-- الأنواع: `Baa*`
-- الثوابت: `BAA_*`
-- المتغيرات العامة: `g_*`
-
-## إرشادات التطوير (Development Guidelines)
-
-1. كل تغيير يجب أن يكون له اختبار
-2. التوثيق بالعربية والإنجليزية
-3. الالتزام بمعايير تنسيق الشيفرة
-4. تحديث سجل التغييرات
-5. مراجعة الشيفرة قبل الدمج
+يهدف هذا الهيكل إلى توفير أساس منظم وقابل للتطوير لمشروع لغة باء.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,42 +1,180 @@
 # Baa Language Roadmap (خارطة الطريق)
 
-## Current Version: 0.1.10.0 (Working towards 0.2.0)
+## Current Version State (Mid-May 2025)
 
-This roadmap outlines the high-level plan for the Baa language project. For detailed status and plans for specific components (Lexer, Parser, AST, Preprocessor), please refer to their respective roadmap documents (`LEXER_ROADMAP.md`, `PARSER_ROADMAP.md`, `AST_ROADMAP.md`, etc.).
+* **Build System:** Refactored to v0.1.18.0 (Modular, Target-Centric CMake)
+* **Preprocessor:** Features up to v0.1.17.0 (C99 alignment, Arabic directives, error recovery foundation)
+* **Lexer:** Functionality largely aligned with v0.1.13.0+ (Arabic numerals, advanced literals, doc comments)
+* **Core (Types, Operators, Utils):** Foundational elements implemented.
+* **Parser & AST:** Previous versions removed; currently **under redesign and re-implementation.**
+* **Analysis:** Basic flow analysis structure exists; full semantic analysis pending new AST.
+* **Codegen:** Basic LLVM integration stubs and conditional build logic in place; actual IR generation pending new AST/Semantic Analysis.
 
-**Note:** The compilation process now includes an explicit **Preprocessor** stage that handles directives (`#تضمين`, `#تعريف`) before the Lexer stage.
+This roadmap outlines the high-level plan for the Baa language project. For detailed status and plans for specific components, please refer to their respective roadmap documents (`LEXER_ROADMAP.md`, `PREPROCESSOR_ROADMAP.md`, `PARSER_ROADMAP.md`, `AST_ROADMAP.md`, `SEMANTIC_ANALYSIS_ROADMAP.md`, `LLVM_CODEGEN_ROADMAP.md`, etc.).
 
-### Immediate Goals (0.2.0)
+---
 
-1.  **Preprocessor Enhancements:** Continue Preprocessor Enhancements: Implement remaining C99 features (Variadic Macros, `__func__`, `#error`, `#pragma`, etc. with Arabic syntax), and full macro expansion in conditional expressions. (Macro rescanning and basic conditionals are now implemented). (See `PREPROCESSOR_ROADMAP.md` for details).
-2.  **Parser Enhancements:** Complete core control flow parsing, restore decimal number parsing, implement full operator precedence, enhance UTF-8 support, add robust error recovery, and implement comprehensive source position tracking. (See `PARSER_ROADMAP.md` for details).
-3.  **Code Generation (Priority):** Complete LLVM integration, implement the basic code emission pipeline (expressions, statements, control flow), add debug information support, and optimize generated code for Arabic text handling.
-4.  **Lexer Enhancements:**
-    - **Completed:** Significantly improved numeric literal scanning (Arabic-Indic digits, binary/hex prefixes, underscores, Arabic decimal separator `٫`). String/char escape handling is robust (`\uXXXX`, standard C escapes; `\'` in strings is an error). Comment skipping (`//`, `/* */`, `#`) is functional. Error message for invalid string escapes clarified. Lexer modularization is complete.
-    - **Ongoing/Next:** Implement planned Arabic syntax for literals (escape sequences, suffixes, float exponent `أ`). Focus on comprehensive testing of all token types, edge case robustness, and ensuring consistent error reporting quality. Review and refine `LEXER_ROADMAP.md`.
-5.  **AST Improvements:** Enhance scope management, improve modularity, implement comprehensive control flow node handling (including `تعداد` for enum), and add robust error state tracking. (See `AST_ROADMAP.md` for details).
+## Phase 1: Core Compiler Infrastructure & Language Basics (Largely Completed/Ongoing Refinement)
 
-### Mid-term Goals (0.3.0)
+### 1.1 Build System & Core Utilities (Status: Refactored & Stable)
 
-1.  **Advanced Language Features:** Modules, custom types (structs/records with `::`/`->` access), exception handling, function overloading.
-2.  **AST and Type System Improvements:** Type inference, generics/templates, user-defined types (unions, enums), improved memory management (ref counting/GC).
-3.  **Lexer and Parser Enhancements:** Improved Unicode/RTL support, enhanced error recovery, better source location tracking.
-4.  **Arabic Language Support:** Complete Arabization of planned language syntax elements (keywords, operators, literals), full RTL support, enhanced Arabic error messages, standard library documentation, formatting tools.
-5.  **Development Tools:** IDE plugins, code completion, real-time syntax checking, debugging tools.
+* [x] Modern CMake build system (target-centric, modular). (v0.1.18.0)
+* [x] Core utilities: Memory management (`baa_malloc`, `baa_strdup`), basic string ops, file I/O.
+* [x] Basic error reporting infrastructure.
 
-### Long-term Goals (0.4.0)
+### 1.2 Preprocessor (Status: Actively Developed, Most C99 Features Implemented)
 
-1.  **Standard Library:** Comprehensive I/O, string manipulation, file system operations, networking, concurrency features.
-2.  **Testing Infrastructure:** Comprehensive test suite, automated pipeline, benchmarking, coverage reporting, specific tests for errors/Unicode/memory.
-3.  **Code Generation and Optimization:** Optimization passes, target-specific optimizations, inline assembly/intrinsics, register allocation, vectorization/SIMD.
-4.  **Error Handling and Diagnostics:** Improved error messages (context/suggestions), warning system, visual error highlighting, error categorization.
-5.  **Documentation and Examples:** Comprehensive language specification, bilingual docs, more examples, tutorials, best practices.
-6.  **Compiler Features:** Incremental compilation, plugin system, enhanced diagnostics, cross-platform support.
+* [x] File inclusion (`#تضمين`) with relative/standard paths, circular include detection.
+* [x] Macro definition (`#تعريف`): object-like, function-like.
+* [x] Macro expansion: Argument substitution, stringification (`#`), token pasting (`##`), variadic macros (`وسائط_إضافية`, `__وسائط_متغيرة__`), **full rescanning**.
+* [x] Macro undefinition (`#الغاء_تعريف`).
+* [x] Conditional compilation (`#إذا`, `#إذا_عرف`, `#إذا_لم_يعرف`, `#وإلا_إذا`, `#إلا`, `#نهاية_إذا`).
+* [x] Expression evaluation in conditionals (arithmetic, comparison, logical, bitwise, `معرف`, numeric literals).
+* [x] Predefined macros (`__الملف__`, `__السطر__` (int), `__التاريخ__`, `__الوقت__`, `__الدالة__` (placeholder), `__إصدار_المعيار_باء__`).
+* [x] `#خطأ` and `#تحذير` directives implemented.
+* [x] Input encoding detection (UTF-8 default, UTF-16LE with BOM).
+* [x] Foundation for multi-error reporting.
+* **Next/Ongoing:**
+  * Complete error recovery mechanisms (systematic updates for robust continuation).
+  * Finalize known issues (e.g., `معرف` argument expansion, complex `##` in rescans).
+  * Implement remaining standard directives (`#سطر`, `#براغما`, `أمر_براغما`).
+  * Full macro expansion (including function-like) *within* conditional expressions.
+  * *See `docs/PREPROCESSOR_ROADMAP.md`.*
 
-### Future Considerations (1.0.0)
+### 1.3 Lexer (Status: Actively Developed, Most Core Features Implemented)
 
-1.  **Language Evolution:** Metaprogramming, generics, pattern matching, concurrency, functional programming features, contract programming.
-2.  **Ecosystem Development:** Package manager, standard library repository, dependency management, community guidelines, build system integration.
-3.  **Tools and Infrastructure:** Online playground, cloud IDE, CI/CD templates, documentation generator, Language Server Protocol (LSP) implementation.
+* [x] Tokenization of preprocessed UTF-16LE stream.
+* [x] Arabic/English identifiers, Arabic-Indic digits, Arabic keywords.
+* [x] Numeric literals: decimal, hex (`0x`), binary (`0b`), underscores, Arabic decimal separator (`٫`), basic scientific notation (`e`/`E`).
+* [x] Integer literal suffixes (`غ`, `ط`, `طط` and combinations) tokenized.
+* [x] String literals (`"..."`, `"""..."""` multiline, `خ"..."` raw).
+* [x] Character literals (`'...'`).
+* [x] Standard C & Unicode (`\uXXXX`) escape sequence processing.
+* [x] Documentation comment token (`/** ... */`).
+* [x] Accurate line/column tracking.
+* **Next/Ongoing:**
+  * Implement Baa-specific Arabic syntax for literals:
+    * Float suffix `ح`.
+    * Float exponent marker `أ`.
+    * Arabic escape sequences (`\س`, `\م`, etc.).
+  * Ensure `number_parser.c` fully interprets all lexed numeric forms with suffixes.
+  * Enhance error handling (specific error tokens/messages, robust synchronization).
+  * Expand unit and fuzz testing.
+  * *See `docs/LEXER_ROADMAP.md`.*
 
-This roadmap is subject to change based on community feedback and project needs. Regular updates will be made to reflect new requirements and priorities.
+### 1.4 Core Language Primitives (Status: Foundational Implementation)
+
+* [x] Basic Type System (`src/types/`): `عدد_صحيح`, `عدد_حقيقي`, `حرف`, `منطقي`, `فراغ`. Array type structure.
+* [x] Operator System (`src/operators/`): Definitions, precedence, basic validation stubs.
+
+---
+
+## Phase 2: Syntactic Analysis - Parser & AST (Current Major Focus: Redesign & Re-implementation)
+
+* **Goal:** Develop a new, robust Parser and Abstract Syntax Tree (AST) representation.
+* **Status:** Previous implementations removed. New design phase is complete, implementation starting.
+
+### 2.1 Abstract Syntax Tree (AST) - New Design
+
+* **(In Progress/Planned)** Define all AST node types (expressions, statements, declarations, types, program structure) as per `docs/AST.md`.
+* **(In Progress/Planned)** Implement standardized node structures, memory management (creation/freeing functions).
+* **(Planned)** Implement AST traversal mechanisms (e.g., Visitor pattern).
+* *See `docs/AST.md` and `docs/AST_ROADMAP.md`.*
+
+### 2.2 Parser - New Design
+
+* **(In Progress/Planned)** Implement core parser infrastructure (recursive descent, token handling, error reporting/recovery).
+* **(In Progress/Planned)** Develop parsing functions for:
+  * Primary expressions (literals, identifiers, grouping).
+  * Unary and binary expressions with correct precedence and associativity.
+  * Assignment expressions.
+  * Basic statements (expression statements, blocks).
+  * Variable declarations (with type annotations and initializers).
+  * Control flow statements (`إذا`, `وإلا`, `طالما`, `لكل`, `إرجع`, `توقف`, `أكمل`, `اختر`).
+  * Function declarations (C-style: name, parameters, return type, body).
+  * Function call expressions.
+  * Type parsing (basic annotations, array types).
+* **(Planned)** Integration with the new AST generation.
+* *See `docs/PARSER.md` and `docs/PARSER_ROADMAP.md`.*
+
+---
+
+## Phase 3: Semantic Analysis (Depends on New Parser & AST)
+
+* **Goal:** Implement semantic checks, name resolution, and type checking. Annotate AST for code generation.
+* **Status:** Basic flow analysis structure in `src/analysis/` exists but needs integration with new AST. Full semantic analysis is planned.
+
+### 3.1 Symbol Table & Name Resolution
+
+* **(Planned)** Design and implement symbol table(s) and scope management (global, function, block).
+* **(Planned)** Implement name resolution for identifiers, handling shadowing.
+* **(Planned)** Report errors for undeclared/ambiguous identifiers.
+
+### 3.2 Type Checking
+
+* **(Planned)** Implement type checking for all expressions, statements, and declarations.
+* **(Planned)** Validate operator usage based on operand types.
+* **(Planned)** Enforce type compatibility for assignments, function calls, return statements.
+* **(Planned)** Define and implement implicit/explicit type conversion rules.
+
+### 3.3 Control Flow Analysis
+
+* **(Planned)** Integrate and adapt existing `flow_analysis.c` for the new AST.
+* **(Planned)** Verify "all paths return" for non-void functions.
+* **(Planned)** Check for unreachable code, valid `break`/`continue` usage.
+
+### 3.4 AST Annotation
+
+* **(Planned)** Annotate AST nodes with resolved types, links to symbol table entries, etc.
+* **(Planned)** Consider AST transformations (e.g., inserting explicit cast nodes).
+* *See `docs/SEMANTIC_ANALYSIS.md` and `docs/SEMANTIC_ANALYSIS_ROADMAP.md`.*
+
+---
+
+## Phase 4: Code Generation (Depends on New Semantically-Analyzed AST)
+
+* **Goal:** Translate the validated and annotated AST into LLVM IR, and subsequently to machine code.
+* **Status:** Basic LLVM integration and stub backend exist. Actual IR generation from AST is pending.
+
+### 4.1 LLVM IR Generation
+
+* **(Planned)** Implement `BaaLLVMCodeGenerator` context.
+* **(Planned)** Develop functions to generate LLVM IR for each AST node type (expressions, statements, functions, control flow).
+* **(Planned)** Map Baa types to LLVM types.
+* **(Planned)** Handle variable allocation (global, local/stack), loads, and stores.
+* **(Planned)** Generate LLVM IR for operators and function calls.
+* *See `docs/LLVM_CODEGEN.md` and `docs/LLVM_CODEGEN_ROADMAP.md`.*
+
+### 4.2 Optimization & Output
+
+* **(Planned)** Integrate LLVM optimization passes.
+* **(Planned)** Implement emission of object files and assembly for target platforms (e.g., x86-64, ARM64, Wasm).
+* **(Planned)** Basic debug information generation.
+
+---
+
+## Phase 5: Language Maturity & Ecosystem (Longer Term)
+
+### 5.1 Advanced Language Features
+
+* **(Future)** User-defined types: `بنية` (structs), `اتحاد` (unions), `تعداد` (enums) with full semantic and codegen support.
+* **(Future)** Pointers (`مؤشر`).
+* **(Future)** Module system.
+* **(Future)** Advanced function features (optional/named parameters, rest parameters).
+* **(Future)** More comprehensive standard library.
+
+### 5.2 Tooling & Developer Experience
+
+* **(Future)** Enhanced debugging support (mapping IR to Baa source).
+* **(Future)** Language Server Protocol (LSP) implementation for IDE integration (autocompletion, diagnostics).
+* **(Future)** Code formatter, linter.
+* **(Future)** Package manager.
+
+### 5.3 Testing & Documentation
+
+* **(Ongoing)** Expand unit and integration test coverage for all components.
+* **(Ongoing)** Develop comprehensive language specification and user tutorials in Arabic and English.
+
+---
+
+This roadmap is a living document and will be updated as the project progresses and priorities evolve. Community feedback is highly encouraged.

--- a/include/baa/utils/utils.h
+++ b/include/baa/utils/utils.h
@@ -5,18 +5,19 @@
 #include <wchar.h>
 
 // دوال إدارة الذاكرة
-void* baa_malloc(size_t size);
-void* baa_realloc(void* ptr, size_t size);
-void baa_free(void* ptr);
+void *baa_malloc(size_t size);
+void *baa_realloc(void *ptr, size_t size);
+void baa_free(void *ptr);
 
 // دوال معالجة النصوص
-wchar_t* baa_strdup(const wchar_t* str);
-wchar_t* baa_strndup(const wchar_t* str, size_t n);
-int baa_strcmp(const wchar_t* s1, const wchar_t* s2);
+wchar_t *baa_strdup(const wchar_t *str);
+wchar_t *baa_strndup(const wchar_t *str, size_t n);
+char *baa_strdup_char(const char *str);
+int baa_strcmp(const wchar_t *s1, const wchar_t *s2);
 
 // دوال معالجة الملفات
-wchar_t* baa_read_file(const wchar_t* filename); // Existing one
-long baa_file_size(FILE *file); // Moved from lexer.h
-wchar_t* baa_file_content(const wchar_t *path); // Moved from lexer.h, might be similar to baa_read_file
+wchar_t *baa_read_file(const wchar_t *filename); // Existing one
+long baa_file_size(FILE *file);                  // Moved from lexer.h
+wchar_t *baa_file_content(const wchar_t *path);  // Moved from lexer.h, might be similar to baa_read_file
 
 #endif /* BAA_UTILS_H */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,3 +7,26 @@ add_subdirectory(preprocessor) # Added missing preprocessor
 add_subdirectory(analysis)
 add_subdirectory(codegen)
 # Parser is removed, so no add_subdirectory(parser)
+
+# --- Compiler Library ---
+# Create a library for the compiler logic itself
+add_library(baa_compiler_lib STATIC
+    compiler.c
+)
+target_include_directories(baa_compiler_lib PRIVATE # Compiler logic likely needs access to all component headers`
+    ${PROJECT_SOURCE_DIR}/include
+)
+target_compile_definitions(baa_compiler_lib PRIVATE # Specific definitions for compiler.c
+    UNICODE
+    _UNICODE
+    _CRT_SECURE_NO_WARNINGS
+)
+target_link_libraries(baa_compiler_lib PRIVATE # Compiler logic uses these
+    baa_utils
+    baa_types
+    baa_operators
+    baa_lexer
+    baa_preprocessor
+    baa_flow_analysis
+    baa_codegen
+)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,11 +16,6 @@ add_library(baa_compiler_lib STATIC
 target_include_directories(baa_compiler_lib PRIVATE # Compiler logic likely needs access to all component headers`
     ${PROJECT_SOURCE_DIR}/include
 )
-target_compile_definitions(baa_compiler_lib PRIVATE # Specific definitions for compiler.c
-    UNICODE
-    _UNICODE
-    _CRT_SECURE_NO_WARNINGS
-)
 target_link_libraries(baa_compiler_lib PRIVATE # Compiler logic uses these
     baa_utils
     baa_types
@@ -29,4 +24,5 @@ target_link_libraries(baa_compiler_lib PRIVATE # Compiler logic uses these
     baa_preprocessor
     baa_flow_analysis
     baa_codegen
+    BaaCommonSettings
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,12 +1,9 @@
 # Add subdirectories for each component
-add_subdirectory(lexer)
-add_subdirectory(codegen)
 add_subdirectory(utils)
 add_subdirectory(types)
 add_subdirectory(operators)
-add_subdirectory(analysis) # Corrected path
-
-# The main executable 'baa' is defined in the root CMakeLists.txt
-# Remove the redundant definition below:
-# add_executable(Baa main.c)
-# target_link_libraries(Baa PRIVATE ...)
+add_subdirectory(lexer)
+add_subdirectory(preprocessor) # Added missing preprocessor
+add_subdirectory(analysis)
+add_subdirectory(codegen)
+# Parser is removed, so no add_subdirectory(parser)

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -10,11 +10,5 @@ target_include_directories(baa_flow_analysis
         ${PROJECT_SOURCE_DIR}/include # Access to baa/analysis/ headers
 )
 
-target_compile_definitions(baa_flow_analysis PUBLIC # Or PRIVATE
-    UNICODE
-    _UNICODE
-    _CRT_SECURE_NO_WARNINGS
-)
-
 # baa_flow_analysis depends on baa_types and baa_utils
-target_link_libraries(baa_flow_analysis PRIVATE baa_types baa_utils)
+target_link_libraries(baa_flow_analysis PRIVATE baa_types baa_utils INTERFACE BaaCommonSettings)

--- a/src/analysis/CMakeLists.txt
+++ b/src/analysis/CMakeLists.txt
@@ -8,14 +8,13 @@ add_library(baa_flow_analysis
 target_include_directories(baa_flow_analysis
     PUBLIC
         ${PROJECT_SOURCE_DIR}/include # Access to baa/analysis/ headers
-    PRIVATE
-        ${PROJECT_SOURCE_DIR}/include # Access to baa/ast/, baa/types/, etc.
 )
 
-# Optional: Install header files if this is part of a public API
-# Dependencies are linked by the final executable, not the static library itself.
-# install(FILES
-#     ${CMAKE_CURRENT_SOURCE_DIR}/../include/baa/analysis/flow_analysis.h
-#     ${CMAKE_CURRENT_SOURCE_DIR}/../include/baa/analysis/flow_errors.h
-#     DESTINATION include/baa/analysis
-# )
+target_compile_definitions(baa_flow_analysis PUBLIC # Or PRIVATE
+    UNICODE
+    _UNICODE
+    _CRT_SECURE_NO_WARNINGS
+)
+
+# baa_flow_analysis depends on baa_types and baa_utils
+target_link_libraries(baa_flow_analysis PRIVATE baa_types baa_utils)

--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -1,38 +1,31 @@
 # Create the library target first
 add_library(baa_codegen)
 
-# Add LLVM-specific files only if LLVM is available
-if(LLVM_AVAILABLE)
+# Add LLVM-specific files only if LLVM is available and found
+if(USE_LLVM AND LLVM_FOUND) # Check both the option and if find_package succeeded
     target_sources(baa_codegen PRIVATE
-        codegen.c      # Compile the main codegen file only if LLVM is found
+        codegen.c
         llvm_codegen.c
     )
-
     target_compile_definitions(baa_codegen PRIVATE
-    LLVM_AVAILABLE=0
+    LLVM_AVAILABLE=1
     )
 
-    # Make sure LLVM CMake modules are included
-    list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}")
-    include(AddLLVM)
+    # Make sure LLVM CMake modules are included (may not be strictly necessary if find_package in root works well)
+    # list(APPEND CMAKE_MODULE_PATH "${LLVM_CMAKE_DIR}") # Likely not needed here
+    # include(AddLLVM) # Likely not needed here
 
     # Get required LLVM libraries
-    llvm_map_components_to_libnames(llvm_libs
-        core
-        support
-        irreader
-        analysis
-        target
-        mcjit
-        native
-        executionengine
-        # Add other components as needed, e.g., MC, Object, BitReader?
-    )
+    # Prefer linking against imported LLVM targets
+    # llvm_map_components_to_libnames(llvm_libs ... )
     # Note: llvm_map_components_to_libnames is useful for older CMake/LLVM versions
     # or specific scenarios, but linking imported targets is generally preferred.
 
     # Print the determined LLVM libraries for debugging (optional)
     # message(STATUS "LLVM Libraries (via map): ${llvm_libs}")
+
+    # Add LLVM include directories
+    target_include_directories(baa_codegen PRIVATE ${LLVM_INCLUDE_DIRS})
 
     # Link against imported LLVM targets
     target_link_libraries(baa_codegen
@@ -48,26 +41,22 @@ if(LLVM_AVAILABLE)
             LLVM::NativeAsmPrinter # Often needed with NativeTarget
             LLVM::NativeAsmParser # If parsing inline asm
             # Add other LLVM:: targets corresponding to the components listed above if needed
+            # ${llvm_libs} # If using llvm_map_components_to_libnames
     )
 else()
     # Add stub implementation when LLVM is not available
     target_sources(baa_codegen PRIVATE
-        codegen.c      # Always compile the main codegen file
+        codegen.c
         llvm_stub.c
     )
-
     target_compile_definitions(baa_codegen PRIVATE
-        -DLLVM_AVAILABLE=0
+    LLVM_AVAILABLE=0
     )
 endif()
 
 target_include_directories(baa_codegen
     PUBLIC
     ${PROJECT_SOURCE_DIR}/include  # For baa/codegen/codegen.h and baa/codegen/llvm_codegen.h
-    PRIVATE
-    # ${CMAKE_SOURCE_DIR}/src/include # This path seems incorrect for this component's private headers.
-    # If codegen.c or llvm_codegen.c need private headers from src/codegen, use ${CMAKE_CURRENT_SOURCE_DIR}
-    ${LLVM_INCLUDE_DIRS} # Only if LLVM_AVAILABLE
 )
 
 target_compile_definitions(baa_codegen PUBLIC # Propagate if public headers depend on them

--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -59,12 +59,6 @@ target_include_directories(baa_codegen
     ${PROJECT_SOURCE_DIR}/include  # For baa/codegen/codegen.h and baa/codegen/llvm_codegen.h
 )
 
-target_compile_definitions(baa_codegen PUBLIC # Propagate if public headers depend on them
-    UNICODE
-    _UNICODE
-    _CRT_SECURE_NO_WARNINGS
-)
-
 # baa_codegen depends on baa_utils and baa_types
 # (assuming AST dependencies in llvm_codegen.c are handled/removed for now)
-target_link_libraries(baa_codegen PRIVATE baa_utils baa_types)
+target_link_libraries(baa_codegen PRIVATE baa_utils baa_types INTERFACE BaaCommonSettings)

--- a/src/codegen/CMakeLists.txt
+++ b/src/codegen/CMakeLists.txt
@@ -9,7 +9,7 @@ if(LLVM_AVAILABLE)
     )
 
     target_compile_definitions(baa_codegen PRIVATE
-        -DLLVM_AVAILABLE=1
+    LLVM_AVAILABLE=0
     )
 
     # Make sure LLVM CMake modules are included
@@ -63,16 +63,19 @@ endif()
 
 target_include_directories(baa_codegen
     PUBLIC
-        ${CMAKE_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/include  # For baa/codegen/codegen.h and baa/codegen/llvm_codegen.h
     PRIVATE
-        ${CMAKE_SOURCE_DIR}/src/include
-        ${LLVM_INCLUDE_DIRS}
+    # ${CMAKE_SOURCE_DIR}/src/include # This path seems incorrect for this component's private headers.
+    # If codegen.c or llvm_codegen.c need private headers from src/codegen, use ${CMAKE_CURRENT_SOURCE_DIR}
+    ${LLVM_INCLUDE_DIRS} # Only if LLVM_AVAILABLE
 )
 
-# Removed redundant linking of utils, types, ast as they are linked in the main executable
-# target_link_libraries(baa_codegen
-#     PRIVATE
-#         baa_utils
-#         baa_types
-#         baa_ast
-# )
+target_compile_definitions(baa_codegen PUBLIC # Propagate if public headers depend on them
+    UNICODE
+    _UNICODE
+    _CRT_SECURE_NO_WARNINGS
+)
+
+# baa_codegen depends on baa_utils and baa_types
+# (assuming AST dependencies in llvm_codegen.c are handled/removed for now)
+target_link_libraries(baa_codegen PRIVATE baa_utils baa_types)

--- a/src/codegen/llvm_codegen.c
+++ b/src/codegen/llvm_codegen.c
@@ -1,7 +1,6 @@
 #include "baa/codegen/llvm_codegen.h"
 #include "baa/utils/utils.h"
 #include "baa/utils/errors.h"
-//#include "baa/ast/literals.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/src/codegen/llvm_codegen.c
+++ b/src/codegen/llvm_codegen.c
@@ -1,7 +1,7 @@
 #include "baa/codegen/llvm_codegen.h"
 #include "baa/utils/utils.h"
 #include "baa/utils/errors.h"
-#include "baa/ast/literals.h"
+//#include "baa/ast/literals.h"
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>

--- a/src/lexer/CMakeLists.txt
+++ b/src/lexer/CMakeLists.txt
@@ -12,9 +12,5 @@ target_include_directories(baa_lexer
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-target_compile_definitions(baa_lexer PUBLIC # Or PRIVATE
-    UNICODE
-    _UNICODE
-    _CRT_SECURE_NO_WARNINGS
-)
+target_link_libraries(baa_lexer INTERFACE BaaCommonSettings)
 # No direct baa_* library dependencies observed for baa_lexer itself.

--- a/src/lexer/CMakeLists.txt
+++ b/src/lexer/CMakeLists.txt
@@ -11,3 +11,10 @@ target_include_directories(baa_lexer
     PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+target_compile_definitions(baa_lexer PUBLIC # Or PRIVATE
+    UNICODE
+    _UNICODE
+    _CRT_SECURE_NO_WARNINGS
+)
+# No direct baa_* library dependencies observed for baa_lexer itself.

--- a/src/operators/CMakeLists.txt
+++ b/src/operators/CMakeLists.txt
@@ -9,11 +9,6 @@ target_include_directories(baa_operators
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-target_compile_definitions(baa_operators PUBLIC # Or PRIVATE
-    UNICODE
-    _UNICODE
-    _CRT_SECURE_NO_WARNINGS
-)
 # baa_operators depends on baa_types
-target_link_libraries(baa_operators PRIVATE baa_types)
+target_link_libraries(baa_operators PRIVATE baa_types INTERFACE BaaCommonSettings)
 # It does not seem to directly depend on baa_utils, but baa_types does.

--- a/src/operators/CMakeLists.txt
+++ b/src/operators/CMakeLists.txt
@@ -9,9 +9,11 @@ target_include_directories(baa_operators
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-# Removed redundant linking of utils, types as they are linked in the main executable
-# target_link_libraries(baa_operators
-#     PRIVATE
-#     baa_utils
-#     baa_types
-# )
+target_compile_definitions(baa_operators PUBLIC # Or PRIVATE
+    UNICODE
+    _UNICODE
+    _CRT_SECURE_NO_WARNINGS
+)
+# baa_operators depends on baa_types
+target_link_libraries(baa_operators PRIVATE baa_types)
+# It does not seem to directly depend on baa_utils, but baa_types does.

--- a/src/preprocessor/CMakeLists.txt
+++ b/src/preprocessor/CMakeLists.txt
@@ -21,9 +21,4 @@ target_include_directories(baa_preprocessor
     ${CMAKE_CURRENT_SOURCE_DIR}   # For preprocessor_internal.h
 )
 
-target_compile_definitions(baa_preprocessor PUBLIC # Or PRIVATE
-    UNICODE
-    _UNICODE
-    _CRT_SECURE_NO_WARNINGS
-)
-target_link_libraries(baa_preprocessor PRIVATE baa_utils)
+target_link_libraries(baa_preprocessor PRIVATE baa_utils INTERFACE BaaCommonSettings)

--- a/src/preprocessor/CMakeLists.txt
+++ b/src/preprocessor/CMakeLists.txt
@@ -16,5 +16,14 @@ add_library(baa_preprocessor STATIC
 # Ensure the library can find the main include directory
 target_include_directories(baa_preprocessor
     PUBLIC
-        ${PROJECT_SOURCE_DIR}/include # Assuming main headers are in root/include
+    ${PROJECT_SOURCE_DIR}/include # For baa/preprocessor/preprocessor.h
+    PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}   # For preprocessor_internal.h
 )
+
+target_compile_definitions(baa_preprocessor PUBLIC # Or PRIVATE
+    UNICODE
+    _UNICODE
+    _CRT_SECURE_NO_WARNINGS
+)
+target_link_libraries(baa_preprocessor PRIVATE baa_utils)

--- a/src/preprocessor/preprocessor_expansion.c
+++ b/src/preprocessor/preprocessor_expansion.c
@@ -385,7 +385,7 @@ wchar_t **parse_macro_arguments(BaaPreprocessor *pp_state, const wchar_t **invoc
             args = new_args;
             args_capacity = new_capacity;
         }
-        args[*actual_arg_count] = _wcsdup(L"");
+        args[*actual_arg_count] = baa_strdup(L"");
         if (!args[*actual_arg_count])
         {
             PpSourceLocation va_dup_loc = get_current_original_location(pp_state);
@@ -521,11 +521,11 @@ bool substitute_macro_body(BaaPreprocessor *pp_state, DynamicWcharBuffer *output
             {
                 if (arg_count > macro->param_count)
                 {
-                    rhs_value_to_paste = _wcsdup(arguments[macro->param_count]);
+                    rhs_value_to_paste = baa_strdup(arguments[macro->param_count]);
                 }
                 else
                 {
-                    rhs_value_to_paste = _wcsdup(L"");
+                    rhs_value_to_paste = baa_strdup(L"");
                 }
             }
             else
@@ -535,13 +535,13 @@ bool substitute_macro_body(BaaPreprocessor *pp_state, DynamicWcharBuffer *output
                 {
                     if (wcscmp(rhs_token_str, macro->param_names[i]) == 0)
                     {
-                        rhs_value_to_paste = (arguments[i][0] == L'\0') ? _wcsdup(L"") : _wcsdup(arguments[i]);
+                        rhs_value_to_paste = (arguments[i][0] == L'\0') ? baa_strdup(L"") : baa_strdup(arguments[i]);
                         rhs_is_param = true;
                         break;
                     }
                 }
                 if (!rhs_is_param)
-                    rhs_value_to_paste = _wcsdup(rhs_token_str);
+                    rhs_value_to_paste = baa_strdup(rhs_token_str);
             }
             free(rhs_token_str);
             if (!rhs_value_to_paste)

--- a/src/preprocessor/preprocessor_expr_eval.c
+++ b/src/preprocessor/preprocessor_expr_eval.c
@@ -388,7 +388,7 @@ static wchar_t *fully_expand_expression_string(BaaPreprocessor *pp_state,
     } while (expansion_made_this_pass && overall_success);
     if (overall_success)
     {
-        final_expanded_string = _wcsdup(current_input_buffer.buffer);
+        final_expanded_string = baa_strdup(current_input_buffer.buffer);
         if (!final_expanded_string)
         {
             PpSourceLocation error_loc = get_current_original_location(pp_state);

--- a/src/preprocessor/preprocessor_macros.c
+++ b/src/preprocessor/preprocessor_macros.c
@@ -64,7 +64,7 @@ bool add_macro(BaaPreprocessor *pp_state, const wchar_t *name, const wchar_t *bo
                 free(pp_state->macros[i].param_names);
             }
 
-            pp_state->macros[i].body = _wcsdup(body);
+            pp_state->macros[i].body = baa_strdup(body);
             pp_state->macros[i].is_function_like = is_function_like;
             pp_state->macros[i].is_variadic = is_function_like ? is_variadic : false; // Variadic only if function-like
             pp_state->macros[i].param_count = param_count;
@@ -98,8 +98,10 @@ bool add_macro(BaaPreprocessor *pp_state, const wchar_t *name, const wchar_t *bo
         if (!new_macros)
         {
             // Free params if reallocation fails, as ownership wasn't transferred
-             if (is_function_like && param_names) {
-                for (size_t j = 0; j < param_count; ++j) free(param_names[j]);
+            if (is_function_like && param_names)
+            {
+                for (size_t j = 0; j < param_count; ++j)
+                    free(param_names[j]);
                 free(param_names);
             }
             return false; // Reallocation failed
@@ -110,8 +112,8 @@ bool add_macro(BaaPreprocessor *pp_state, const wchar_t *name, const wchar_t *bo
 
     // Add the new macro
     BaaMacro *new_entry = &pp_state->macros[pp_state->macro_count];
-    new_entry->name = _wcsdup(name);
-    new_entry->body = _wcsdup(body);
+    new_entry->name = baa_strdup(name);
+    new_entry->body = baa_strdup(body);
     new_entry->is_function_like = is_function_like;
     new_entry->is_variadic = is_function_like ? is_variadic : false; // Variadic only if function-like
     new_entry->param_count = param_count;
@@ -121,8 +123,8 @@ bool add_macro(BaaPreprocessor *pp_state, const wchar_t *name, const wchar_t *bo
     if (!new_entry->name || !new_entry->body)
     {
         // Clean up everything allocated for this new entry on failure
-        free(new_entry->name); // Safe even if NULL
-        free(new_entry->body); // Safe even if NULL
+        free(new_entry->name);                                           // Safe even if NULL
+        free(new_entry->body);                                           // Safe even if NULL
         if ((is_function_like || new_entry->is_variadic) && param_names) // Use new_entry->is_variadic here
         {
             for (size_t j = 0; j < param_count; ++j)

--- a/src/preprocessor/preprocessor_utils.c
+++ b/src/preprocessor/preprocessor_utils.c
@@ -77,14 +77,14 @@ wchar_t *format_preprocessor_error_at_location(const PpSourceLocation *location,
         if (needed_fallback < 0)
         {
             va_end(args_fallback);
-            return _wcsdup(L"فشل في تنسيق رسالة الخطأ (وفشل تخصيص البادئة).");
+            return baa_strdup(L"فشل في تنسيق رسالة الخطأ (وفشل تخصيص البادئة).");
         }
         size_t buffer_size_fallback = (size_t)needed_fallback + 1;
         wchar_t *buffer_fallback = malloc(buffer_size_fallback * sizeof(wchar_t));
         if (!buffer_fallback)
         {
             va_end(args_fallback);
-            return _wcsdup(L"فشل في تنسيق رسالة الخطأ (وفشل تخصيص البادئة والمخزن المؤقت).");
+            return baa_strdup(L"فشل في تنسيق رسالة الخطأ (وفشل تخصيص البادئة والمخزن المؤقت).");
         }
         vswprintf(buffer_fallback, buffer_size_fallback, format, args_fallback);
         va_end(args_fallback);
@@ -122,14 +122,14 @@ wchar_t *format_preprocessor_error_at_location(const PpSourceLocation *location,
         if (needed_fallback < 0)
         {
             va_end(args_fallback);
-            return _wcsdup(L"فشل في تنسيق رسالة الخطأ (وفشل تحويل البادئة).");
+            return baa_strdup(L"فشل في تنسيق رسالة الخطأ (وفشل تحويل البادئة).");
         }
         size_t buffer_size_fallback = (size_t)needed_fallback + 1;
         wchar_t *buffer_fallback = malloc(buffer_size_fallback * sizeof(wchar_t));
         if (!buffer_fallback)
         {
             va_end(args_fallback);
-            return _wcsdup(L"فشل في تنسيق رسالة الخطأ (وفشل تحويل البادئة والمخزن المؤقت).");
+            return baa_strdup(L"فشل في تنسيق رسالة الخطأ (وفشل تحويل البادئة والمخزن المؤقت).");
         }
         vswprintf(buffer_fallback, buffer_size_fallback, format, args_fallback);
         va_end(args_fallback);
@@ -148,7 +148,7 @@ wchar_t *format_preprocessor_error_at_location(const PpSourceLocation *location,
     {
         va_end(args);
         free(prefix_w);
-        return _wcsdup(L"فشل في تنسيق جزء الرسالة من خطأ المعالج المسبق.");
+        return baa_strdup(L"فشل في تنسيق جزء الرسالة من خطأ المعالج المسبق.");
     }
 
     // Combine prefix and message (same logic as before)
@@ -161,7 +161,7 @@ wchar_t *format_preprocessor_error_at_location(const PpSourceLocation *location,
     {
         va_end(args);
         free(prefix_w);
-        return _wcsdup(L"فشل في تخصيص الذاكرة لرسالة خطأ المعالج المسبق الكاملة.");
+        return baa_strdup(L"فشل في تخصيص الذاكرة لرسالة خطأ المعالج المسبق الكاملة.");
     }
 
     wcscpy(final_buffer, prefix_w);
@@ -192,14 +192,14 @@ wchar_t *format_preprocessor_warning_at_location(const PpSourceLocation *locatio
         if (needed_fallback < 0)
         {
             va_end(args_fallback);
-            return _wcsdup(L"فشل في تنسيق رسالة التحذير (وفشل تخصيص البادئة).");
+            return baa_strdup(L"فشل في تنسيق رسالة التحذير (وفشل تخصيص البادئة).");
         }
         size_t buffer_size_fallback = (size_t)needed_fallback + 1;
         wchar_t *buffer_fallback = malloc(buffer_size_fallback * sizeof(wchar_t));
         if (!buffer_fallback)
         {
             va_end(args_fallback);
-            return _wcsdup(L"فشل في تنسيق رسالة التحذير (وفشل تخصيص البادئة والمخزن المؤقت).");
+            return baa_strdup(L"فشل في تنسيق رسالة التحذير (وفشل تخصيص البادئة والمخزن المؤقت).");
         }
         vswprintf(buffer_fallback, buffer_size_fallback, format, args_fallback);
         va_end(args_fallback);
@@ -237,14 +237,14 @@ wchar_t *format_preprocessor_warning_at_location(const PpSourceLocation *locatio
         if (needed_fallback < 0)
         {
             va_end(args_fallback);
-            return _wcsdup(L"فشل في تنسيق رسالة التحذير (وفشل تحويل البادئة).");
+            return baa_strdup(L"فشل في تنسيق رسالة التحذير (وفشل تحويل البادئة).");
         }
         size_t buffer_size_fallback = (size_t)needed_fallback + 1;
         wchar_t *buffer_fallback = malloc(buffer_size_fallback * sizeof(wchar_t));
         if (!buffer_fallback)
         {
             va_end(args_fallback);
-            return _wcsdup(L"فشل في تنسيق رسالة التحذير (وفشل تحويل البادئة والمخزن المؤقت).");
+            return baa_strdup(L"فشل في تنسيق رسالة التحذير (وفشل تحويل البادئة والمخزن المؤقت).");
         }
         vswprintf(buffer_fallback, buffer_size_fallback, format, args_fallback);
         va_end(args_fallback);
@@ -263,7 +263,7 @@ wchar_t *format_preprocessor_warning_at_location(const PpSourceLocation *locatio
     {
         va_end(args);
         free(prefix_w);
-        return _wcsdup(L"فشل في تنسيق جزء الرسالة من تحذير المعالج المسبق.");
+        return baa_strdup(L"فشل في تنسيق جزء الرسالة من تحذير المعالج المسبق.");
     }
 
     // Combine prefix and message
@@ -276,7 +276,7 @@ wchar_t *format_preprocessor_warning_at_location(const PpSourceLocation *locatio
     {
         va_end(args);
         free(prefix_w);
-        return _wcsdup(L"فشل في تخصيص الذاكرة لرسالة تحذير المعالج المسبق الكاملة.");
+        return baa_strdup(L"فشل في تخصيص الذاكرة لرسالة تحذير المعالج المسبق الكاملة.");
     }
 
 #ifdef _WIN32
@@ -658,9 +658,9 @@ char *get_absolute_path(const char *file_path)
 char *get_directory_part(const char *file_path)
 {
 #ifdef _WIN32
-    char *path_copy = _strdup(file_path);
+    char *path_copy = baa_strdup_char(file_path);
 #else
-    char *path_copy = _strdup(file_path); // Use _strdup here too
+    char *path_copy = baa_strdup_char(file_path); // Use _strdup here too
 #endif
     if (!path_copy)
         return NULL;
@@ -695,7 +695,7 @@ char *get_directory_part(const char *file_path)
     return dir_part;
 #else
     char *dir_name_result = dirname(path_copy);
-    char *dir_part = _strdup(dir_name_result); // Use _strdup here too
+    char *dir_part = baa_strdup_char(dir_name_result); // Use _strdup here too
     free(path_copy);
     return dir_part;
 #endif
@@ -723,7 +723,7 @@ bool push_file_stack(BaaPreprocessor *pp, const char *abs_path)
         pp->open_files_capacity = new_capacity;
     }
 
-    char *path_copy = _strdup(abs_path); // Use _strdup here
+    char *path_copy = baa_strdup_char(abs_path); // Use _strdup here
     if (!path_copy)
         return false;
     pp->open_files_stack[pp->open_files_count++] = path_copy;

--- a/src/types/CMakeLists.txt
+++ b/src/types/CMakeLists.txt
@@ -9,10 +9,5 @@ target_include_directories(baa_types
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-target_compile_definitions(baa_types PUBLIC # Or PRIVATE if only types.c needs them
-    UNICODE
-    _UNICODE
-    _CRT_SECURE_NO_WARNINGS
-)
 # baa_types depends on baa_utils for baa_malloc, baa_strdup, etc.
-target_link_libraries(baa_types PRIVATE baa_utils)
+target_link_libraries(baa_types PRIVATE baa_utils INTERFACE BaaCommonSettings)

--- a/src/types/CMakeLists.txt
+++ b/src/types/CMakeLists.txt
@@ -9,4 +9,10 @@ target_include_directories(baa_types
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
 
-# Dependencies are linked by the final executable, not the static library itself.
+target_compile_definitions(baa_types PUBLIC # Or PRIVATE if only types.c needs them
+    UNICODE
+    _UNICODE
+    _CRT_SECURE_NO_WARNINGS
+)
+# baa_types depends on baa_utils for baa_malloc, baa_strdup, etc.
+target_link_libraries(baa_types PRIVATE baa_utils)

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -8,3 +8,9 @@ target_include_directories(baa_utils
     PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
+
+target_compile_definitions(baa_utils PUBLIC # Or PRIVATE if only utils.c needs them
+    UNICODE
+    _UNICODE
+    _CRT_SECURE_NO_WARNINGS
+)

--- a/src/utils/CMakeLists.txt
+++ b/src/utils/CMakeLists.txt
@@ -8,9 +8,5 @@ target_include_directories(baa_utils
     PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}
 )
-
-target_compile_definitions(baa_utils PUBLIC # Or PRIVATE if only utils.c needs them
-    UNICODE
-    _UNICODE
-    _CRT_SECURE_NO_WARNINGS
-)
+# Common settings are inherited by linking Baa::CommonSettings
+target_link_libraries(baa_utils INTERFACE BaaCommonSettings)

--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -9,68 +9,85 @@
 static BaaError current_error = BAA_SUCCESS;
 static wchar_t error_message[1024] = {0};
 
-void baa_set_error(BaaError error, const wchar_t *message) {
+void baa_set_error(BaaError error, const wchar_t *message)
+{
     current_error = error;
-    if (message) {
-        wcsncpy(error_message, message, sizeof(error_message)/sizeof(wchar_t) - 1);
-        error_message[sizeof(error_message)/sizeof(wchar_t) - 1] = L'\0';
-    } else {
+    if (message)
+    {
+        wcsncpy(error_message, message, sizeof(error_message) / sizeof(wchar_t) - 1);
+        error_message[sizeof(error_message) / sizeof(wchar_t) - 1] = L'\0';
+    }
+    else
+    {
         error_message[0] = L'\0';
     }
 }
 
-const wchar_t *baa_get_error_message(void) {
+const wchar_t *baa_get_error_message(void)
+{
     return error_message;
 }
 
-BaaError baa_get_error(void) {
+BaaError baa_get_error(void)
+{
     return current_error;
 }
 
-void *baa_malloc(size_t size) {
+void *baa_malloc(size_t size)
+{
     void *ptr = malloc(size);
-    if (!ptr) {
+    if (!ptr)
+    {
         baa_set_error(BAA_ERROR_MEMORY, L"فشل في تخصيص الذاكرة");
     }
     return ptr;
 }
 
-void *baa_realloc(void *ptr, size_t size) {
+void *baa_realloc(void *ptr, size_t size)
+{
     void *new_ptr = realloc(ptr, size);
-    if (!new_ptr) {
+    if (!new_ptr)
+    {
         baa_set_error(BAA_ERROR_MEMORY, L"فشل في إعادة تخصيص الذاكرة");
     }
     return new_ptr;
 }
 
-void baa_free(void *ptr) {
+void baa_free(void *ptr)
+{
     free(ptr);
 }
 
-wchar_t *baa_strdup(const wchar_t *str) {
-    if (!str) {
+wchar_t *baa_strdup(const wchar_t *str)
+{
+    if (!str)
+    {
         return NULL;
     }
 
     size_t len = wcslen(str) + 1;
     wchar_t *new_str = baa_malloc(len * sizeof(wchar_t));
 
-    if (new_str) {
+    if (new_str)
+    {
         wcscpy(new_str, str);
     }
 
     return new_str;
 }
 
-wchar_t *baa_strndup(const wchar_t *str, size_t n) {
-    if (!str) {
+wchar_t *baa_strndup(const wchar_t *str, size_t n)
+{
+    if (!str)
+    {
         return NULL;
     }
 
     size_t len = wcsnlen(str, n);
     wchar_t *new_str = baa_malloc((len + 1) * sizeof(wchar_t));
 
-    if (new_str) {
+    if (new_str)
+    {
         wcsncpy(new_str, str, len);
         new_str[len] = L'\0';
     }
@@ -78,8 +95,29 @@ wchar_t *baa_strndup(const wchar_t *str, size_t n) {
     return new_str;
 }
 
-int baa_strcmp(const wchar_t *s1, const wchar_t *s2) {
-    if (!s1 || !s2) {
+char *baa_strdup_char(const char *str)
+{
+    if (!str)
+    {
+        return NULL;
+    }
+    size_t len = strlen(str) + 1;
+    char *new_str = baa_malloc(len); // Uses your baa_malloc
+    if (new_str)
+    {
+#ifdef _WIN32
+        strcpy_s(new_str, len, str);
+#else
+        strcpy(new_str, str);
+#endif
+    }
+    return new_str;
+}
+
+int baa_strcmp(const wchar_t *s1, const wchar_t *s2)
+{
+    if (!s1 || !s2)
+    {
         return s1 ? 1 : (s2 ? -1 : 0);
     }
     return wcscmp(s1, s2);
@@ -91,16 +129,18 @@ int baa_strcmp(const wchar_t *s1, const wchar_t *s2) {
  * @param filename The path to the file to read
  * @return A newly allocated string with the file contents, or NULL on error
  */
-wchar_t* baa_read_file(const wchar_t* filename) {
-    FILE* file = NULL;
+wchar_t *baa_read_file(const wchar_t *filename)
+{
+    FILE *file = NULL;
 
 #ifdef _WIN32
     file = _wfopen(filename, L"rb");
 #else
     // Convert wchar_t* to char* for non-Windows systems
     size_t len = wcslen(filename);
-    char* narrow_filename = (char*)malloc(len * 4 + 1); // UTF-8 can use up to 4 bytes per character
-    if (!narrow_filename) {
+    char *narrow_filename = (char *)malloc(len * 4 + 1); // UTF-8 can use up to 4 bytes per character
+    if (!narrow_filename)
+    {
         baa_set_error(BAA_ERROR_MEMORY, L"فشل في تخصيص الذاكرة");
         return NULL;
     }
@@ -112,7 +152,8 @@ wchar_t* baa_read_file(const wchar_t* filename) {
     free(narrow_filename);
 #endif
 
-    if (!file) {
+    if (!file)
+    {
         baa_set_error(BAA_ERROR_FILE_OPEN, L"فشل في فتح الملف");
         return NULL;
     }
@@ -122,15 +163,17 @@ wchar_t* baa_read_file(const wchar_t* filename) {
     long file_size = ftell(file);
     fseek(file, 0, SEEK_SET);
 
-    if (file_size <= 0) {
+    if (file_size <= 0)
+    {
         fclose(file);
         baa_set_error(BAA_ERROR_FILE_EMPTY, L"الملف فارغ أو غير صالح");
         return NULL;
     }
 
     // Allocate buffer for file content
-    char* buffer = (char*)malloc(file_size + 1);
-    if (!buffer) {
+    char *buffer = (char *)malloc(file_size + 1);
+    if (!buffer)
+    {
         fclose(file);
         baa_set_error(BAA_ERROR_MEMORY, L"فشل في تخصيص الذاكرة");
         return NULL;
@@ -140,7 +183,8 @@ wchar_t* baa_read_file(const wchar_t* filename) {
     size_t read_size = fread(buffer, 1, file_size, file);
     fclose(file);
 
-    if (read_size != (size_t)file_size) {
+    if (read_size != (size_t)file_size)
+    {
         free(buffer);
         baa_set_error(BAA_ERROR_FILE_READ, L"فشل في قراءة الملف");
         return NULL;
@@ -150,14 +194,16 @@ wchar_t* baa_read_file(const wchar_t* filename) {
 
     // Convert to wide string
     size_t wide_len = mbstowcs(NULL, buffer, 0) + 1;
-    if (wide_len == (size_t)-1) {
+    if (wide_len == (size_t)-1)
+    {
         free(buffer);
         baa_set_error(BAA_ERROR_ENCODING, L"فشل في تحويل الترميز");
         return NULL;
     }
 
-    wchar_t* wide_buffer = (wchar_t*)malloc(wide_len * sizeof(wchar_t));
-    if (!wide_buffer) {
+    wchar_t *wide_buffer = (wchar_t *)malloc(wide_len * sizeof(wchar_t));
+    if (!wide_buffer)
+    {
         free(buffer);
         baa_set_error(BAA_ERROR_MEMORY, L"فشل في تخصيص الذاكرة");
         return NULL;
@@ -201,7 +247,8 @@ wchar_t *baa_file_content(const wchar_t *path)
 #ifdef _WIN32
     // Use _wfopen_s on Windows for potentially non-ASCII paths
     errno_t err = _wfopen_s(&file, path, L"rb"); // Removed ", ccs=UTF-16LE" as BOM check is manual
-    if (err != 0) {
+    if (err != 0)
+    {
         // baa_set_error(BAA_ERROR_FILE_OPEN, L"فشل في فتح الملف"); // Consider using baa_set_error
         printf("لا يمكن فتح الملف (wfopen_s)\n");
         return NULL;
@@ -209,23 +256,26 @@ wchar_t *baa_file_content(const wchar_t *path)
 #else
     // Convert wchar_t* to char* for non-Windows systems
     size_t len = wcslen(path);
-    char* narrow_path = (char*)malloc(len * 4 + 1); // Max UTF-8 bytes
-    if (!narrow_path) {
+    char *narrow_path = (char *)malloc(len * 4 + 1); // Max UTF-8 bytes
+    if (!narrow_path)
+    {
         // baa_set_error(BAA_ERROR_MEMORY, L"فشل في تخصيص الذاكرة لمسار الملف");
         printf("فشل تخصيص الذاكرة لمسار الملف\n");
         return NULL;
     }
-    if (wcstombs(narrow_path, path, len * 4) == (size_t)-1) {
+    if (wcstombs(narrow_path, path, len * 4) == (size_t)-1)
+    {
         free(narrow_path);
         // baa_set_error(BAA_ERROR_ENCODING, L"فشل في تحويل مسار الملف إلى متعدد البايتات");
         printf("فشل تحويل مسار الملف\n");
         return NULL;
     }
-    narrow_path[len*4] = '\0'; // Ensure null termination if wcstombs doesn't fill buffer
+    narrow_path[len * 4] = '\0'; // Ensure null termination if wcstombs doesn't fill buffer
 
     file = fopen(narrow_path, "rb");
     free(narrow_path);
-    if (!file) {
+    if (!file)
+    {
         // baa_set_error(BAA_ERROR_FILE_OPEN, L"فشل في فتح الملف");
         printf("لا يمكن فتح الملف (fopen)\n");
         return NULL;
@@ -234,34 +284,41 @@ wchar_t *baa_file_content(const wchar_t *path)
 
     // Skip BOM if present (UTF-16LE BOM is FF FE)
     unsigned char bom_check[2];
-    if (fread(bom_check, 1, 2, file) == 2) {
-        if (bom_check[0] != 0xFF || bom_check[1] != 0xFE) {
+    if (fread(bom_check, 1, 2, file) == 2)
+    {
+        if (bom_check[0] != 0xFF || bom_check[1] != 0xFE)
+        {
             fseek(file, 0, SEEK_SET); // Not a UTF-16LE BOM, rewind
         }
         // If it is a BOM, we've consumed it.
-    } else {
+    }
+    else
+    {
         fseek(file, 0, SEEK_SET); // Couldn't read 2 bytes, rewind.
     }
 
-
     long file_size_bytes = baa_file_size(file); // Use the utility function
-    if (file_size_bytes <= 0 && ftell(file) == 0) { // Check if file is truly empty or baa_file_size failed
-         // If ftell is also 0 after BOM check and rewind, it might be an empty file or just BOM
+    if (file_size_bytes <= 0 && ftell(file) == 0)
+    {   // Check if file is truly empty or baa_file_size failed
+        // If ftell is also 0 after BOM check and rewind, it might be an empty file or just BOM
         fseek(file, 0, SEEK_END);
         file_size_bytes = ftell(file); // Re-check size from current position
-        fseek(file, 0, SEEK_SET); // Rewind to start after BOM check
+        fseek(file, 0, SEEK_SET);      // Rewind to start after BOM check
 
         // Re-read and check BOM after ensuring position
-        if (fread(bom_check, 1, 2, file) == 2) {
-            if (bom_check[0] != 0xFF || bom_check[1] != 0xFE) {
+        if (fread(bom_check, 1, 2, file) == 2)
+        {
+            if (bom_check[0] != 0xFF || bom_check[1] != 0xFE)
+            {
                 fseek(file, 0, SEEK_SET);
             }
-        } else {
+        }
+        else
+        {
             fseek(file, 0, SEEK_SET);
         }
         file_size_bytes = baa_file_size(file); // Final check
     }
-
 
     // Correct calculation for content size after BOM handling
     long current_pos = ftell(file);
@@ -271,19 +328,22 @@ wchar_t *baa_file_content(const wchar_t *path)
 
     long content_size_bytes_actual = end_pos - current_pos;
 
-    if (content_size_bytes_actual < 0) content_size_bytes_actual = 0;
+    if (content_size_bytes_actual < 0)
+        content_size_bytes_actual = 0;
 
-
-    if (content_size_bytes_actual == 0) { // File is empty or only BOM
+    if (content_size_bytes_actual == 0)
+    { // File is empty or only BOM
         fclose(file);
         wchar_t *contents = baa_malloc(sizeof(wchar_t));
-        if (!contents) return NULL;
+        if (!contents)
+            return NULL;
         contents[0] = L'\0';
         return contents;
     }
 
     // Ensure size is multiple of wchar_t for direct wchar_t reading
-    if (content_size_bytes_actual % sizeof(wchar_t) != 0) {
+    if (content_size_bytes_actual % sizeof(wchar_t) != 0)
+    {
         fclose(file);
         // baa_set_error(BAA_ERROR_FILE_FORMAT, L"حجم الملف غير متوافق مع UTF-16LE");
         printf("حجم الملف غير متوافق مع UTF-16LE\n");
@@ -293,7 +353,8 @@ wchar_t *baa_file_content(const wchar_t *path)
     size_t char_count = (content_size_bytes_actual / sizeof(wchar_t));
     wchar_t *contents = baa_malloc((char_count + 1) * sizeof(wchar_t));
 
-    if (!contents) {
+    if (!contents)
+    {
         fclose(file);
         // baa_set_error(BAA_ERROR_MEMORY, L"فشل تخصيص الذاكرة لمحتوى الملف");
         return NULL;
@@ -304,7 +365,8 @@ wchar_t *baa_file_content(const wchar_t *path)
 
     fclose(file);
 
-    if (chars_read != char_count) {
+    if (chars_read != char_count)
+    {
         // Potentially partial read, though fread itself doesn't distinguish short read from error easily
         // baa_set_error(BAA_ERROR_FILE_READ, L"فشل في قراءة محتوى الملف بالكامل");
         // For now, return what was read, null-terminated.


### PR DESCRIPTION
This pull request introduces significant improvements to the CMake build system for the Baa programming language, focusing on modularity, maintainability, and modern CMake practices. Key changes include adopting a target-centric approach, enforcing out-of-source builds, centralizing common compiler settings, and refining the handling of dependencies and LLVM integration.

### CMake Build System Enhancements:

* **Target-Centric Refactoring:**
  - Replaced global `include_directories()` and `add_definitions()` with `target_include_directories()` and `target_compile_definitions()` for per-target configuration.
  - Component libraries now explicitly declare dependencies using `target_link_libraries()` for better build order and transitive dependency management.
  - The main `baa` executable and tool executables (`baa_lexer_tester`, `baa_preprocessor_tester`) now link against component libraries instead of compiling sources directly. [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR2-L66) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aL76-R101)

* **Centralized Compiler Settings:**
  - Introduced `BaaCommonSettings` as an interface library to manage common compile definitions (`UNICODE`, `_UNICODE`, `_CRT_SECURE_NO_WARNINGS`) across all targets. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR11-R15) [[2]](diffhunk://#diff-fd721d50646fb92cb047c2757ce45a2e8de3efb0ef746f3c7e460341b40851e9R1-R16)

* **Out-of-Source Build Enforcement:**
  - Added a check in the root `CMakeLists.txt` to prevent in-source builds and guide users to create a separate build directory.

* **LLVM Integration Refinement:**
  - Centralized LLVM-specific logic in `src/codegen/CMakeLists.txt` for the `baa_codegen` target, based on `USE_LLVM` and `LLVM_FOUND` status.
  - Adjusted `find_package(LLVM)` to handle `LLVM_FOUND` explicitly and ensure fallback to a stub backend when LLVM is unavailable.

### Documentation Updates:

* Updated `docs/CMAKE_ROADMAP.md` to reflect the completed refactoring steps and outline future improvements, including installation rules, testing infrastructure, and packaging support.