### PR TITLE
Simple cross-platform Fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,7 +27,13 @@ endif()
 # إعداد معيار لغة C
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
-set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /IGNORE:4006 /IGNORE:4099") # Ignore certain linker warnings if needed
+if (WIN32)
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /IGNORE:4006 /IGNORE:4099") # Ignore certain linker warnings if needed
+else()
+    # Linux/macOS specific linker options (none needed here for these specific ignores)
+    # target_link_options(your_target PRIVATE "-Wl,--no-warn-mismatch") # Example for a common Linux linker option
+endif()
+
 
 add_subdirectory(src)
 

--- a/src/lexer/number_parser.c
+++ b/src/lexer/number_parser.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <math.h>
+#include <limits.h>
 
 // Forward declaration for baa_is_arabic_digit
 bool baa_is_arabic_digit(wchar_t c);

--- a/src/preprocessor/preprocessor_core.c
+++ b/src/preprocessor/preprocessor_core.c
@@ -1,5 +1,5 @@
 #include "preprocessor_internal.h"
-
+#include <wctype.h>
 // --- Core Recursive Processing Function ---
 
 // Processes a single file, handling includes recursively.

--- a/src/preprocessor/preprocessor_directives.c
+++ b/src/preprocessor/preprocessor_directives.c
@@ -1,5 +1,5 @@
 #include "preprocessor_internal.h"
-
+#include <wctype.h>
 // Handles a line identified as starting with a preprocessor directive '#'.
 // Modifies pp_state (conditional stack, macros, skipping state).
 // May append output to output_buffer (for #include).

--- a/src/preprocessor/preprocessor_expansion.c
+++ b/src/preprocessor/preprocessor_expansion.c
@@ -1,4 +1,5 @@
 #include "preprocessor_internal.h"
+#include <wctype.h>
 
 // --- Macro Expansion Stack Implementation ---
 

--- a/src/preprocessor/preprocessor_expr_eval.c
+++ b/src/preprocessor/preprocessor_expr_eval.c
@@ -1,4 +1,5 @@
 #include "preprocessor_internal.h"
+#include <wctype.h>
 
 // --- Preprocessor Expression Evaluation Implementation ---
 

--- a/src/preprocessor/preprocessor_utils.c
+++ b/src/preprocessor/preprocessor_utils.c
@@ -1,4 +1,7 @@
 #include "preprocessor_internal.h"
+#include <iconv.h>
+#include <errno.h> // For errno
+#include <string.h> // For strlen
 
 // --- Location Stack ---
 

--- a/src/utils/utils.c
+++ b/src/utils/utils.c
@@ -4,6 +4,7 @@
 #include <string.h>
 #include <wchar.h>
 #include <stdio.h>
+#include <errno.h>
 
 // Error handling state
 static BaaError current_error = BAA_SUCCESS;
@@ -222,7 +223,7 @@ long baa_file_size(FILE *file)
     {
         return 0;
     }
-    fpos_t original = 0;
+    fpos_t original;
     if (fgetpos(file, &original) != 0)
     {
         // Consider using baa_set_error here or a more robust error handling


### PR DESCRIPTION
This pull request includes changes to improve platform-specific compatibility, add necessary library headers, and fix minor issues in the codebase. The most important changes involve adding platform-specific linker flags, including missing headers for functionality, and fixing an initialization issue in `baa_file_size`.

### Platform-specific compatibility:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR30-R36): Added conditional logic to set linker flags for Windows (`/IGNORE:4006 /IGNORE:4099`) and provided comments for potential Linux/macOS linker options.

### Header inclusions for functionality:

* [`src/lexer/number_parser.c`](diffhunk://#diff-38918342c30a17c71c258db61c437c6d7937e527f6865aac34b57d06954a68aaR5): Added `<limits.h>` for numeric limits definitions.
* `src/preprocessor/preprocessor_core.c`, `src/preprocessor/preprocessor_directives.c`, `src/preprocessor/preprocessor_expansion.c`, `src/preprocessor/preprocessor_expr_eval.c`: Included `<wctype.h>` for wide character classification and handling. [[1]](diffhunk://#diff-eedeef02859b2ab8dde113c6668adce9e49e2d45f3a6cee16a99892a3efb9978L2-R2) [[2]](diffhunk://#diff-4d25a48c8145383ac9e3c65ffeb3ce10d670bf98a6af758315e35d69fb79bf0aL2-R2) [[3]](diffhunk://#diff-d73ca42d223db1116f8dcf0f3b0722eb2e064a405292a545a3dde8ccb4e6d0c8R2) [[4]](diffhunk://#diff-15e86eb927a621d3d9d1a164cd75663d99c689f28548ee5d1d39e8a8213951d3R2)
* [`src/preprocessor/preprocessor_utils.c`](diffhunk://#diff-a1d0e412f041568d2c16b6b5b24fa67d1fc9e7b623a51168661d0dc74891efb0R2-R4): Added `<iconv.h>` for character set conversion, `<errno.h>` for error reporting, and `<string.h>` for string manipulation.
* [`src/utils/utils.c`](diffhunk://#diff-172b5bcee8a61f986b74e03a22c257fcc9175fd87c7cc38ba57b6692ee98e178R7): Included `<errno.h>` for error handling in utility functions.

### Minor fixes:

* [`src/utils/utils.c`](diffhunk://#diff-172b5bcee8a61f986b74e03a22c257fcc9175fd87c7cc38ba57b6692ee98e178L225-R226): Removed redundant initialization of the `fpos_t original` variable in the `baa_file_size` function.