### PR TITLE
support: improve read_file diagnostics and validate input path

### DIFF
--- a/src/support/read_file.c
+++ b/src/support/read_file.c
@@ -13,7 +13,7 @@ static void read_file_die(FILE* f, char* buffer, const char* msg)
 {
     if (f) fclose(f);
     free(buffer);
-    printf("%s\n", msg);
+    fprintf(stderr, "%s\n", msg);
     exit(1);
 }
 
@@ -32,19 +32,19 @@ static void read_file_die_path(FILE* f, char* buffer, const char* path, ReadFile
     switch (err)
     {
         case READ_FILE_ERR_OPEN:
-            printf("Error: Could not open input file '%s'\n", path);
+            fprintf(stderr, "خطأ: تعذّر فتح ملف الإدخال '%s'\n", path);
             break;
         case READ_FILE_ERR_SEEK:
-            printf("Error: Could not seek input file '%s'\n", path);
+            fprintf(stderr, "خطأ: تعذّر تحريك مؤشر ملف الإدخال '%s'\n", path);
             break;
         case READ_FILE_ERR_SIZE:
-            printf("Error: Could not read size of input file '%s'\n", path);
+            fprintf(stderr, "خطأ: تعذّر قراءة حجم ملف الإدخال '%s'\n", path);
             break;
         case READ_FILE_ERR_READ:
-            printf("Error: Could not read input file '%s'\n", path);
+            fprintf(stderr, "خطأ: تعذّرت قراءة ملف الإدخال '%s'\n", path);
             break;
         default:
-            printf("Error: Could not read input file '%s'\n", path);
+            fprintf(stderr, "خطأ: تعذّرت قراءة ملف الإدخال '%s'\n", path);
             break;
     }
     exit(1);
@@ -52,6 +52,11 @@ static void read_file_die_path(FILE* f, char* buffer, const char* path, ReadFile
 
 char *read_file(const char *path)
 {
+    if (!path || path[0] == '\0')
+    {
+        read_file_die(NULL, NULL, "خطأ: مسار ملف الإدخال غير صالح");
+    }
+
     FILE *f = fopen(path, "rb");
     if (!f)
     {
@@ -77,7 +82,7 @@ char *read_file(const char *path)
     char *buffer = (char *)malloc((size_t)length + 1);
     if (!buffer)
     {
-        read_file_die(f, NULL, "Error: Memory allocation failed");
+        read_file_die(f, NULL, "خطأ: فشل حجز الذاكرة لقراءة الملف");
     }
 
     size_t got = fread(buffer, 1, (size_t)length, f);


### PR DESCRIPTION
### Motivation
- Ensure file-read failures report to the proper diagnostics channel, provide Arabic-first error messages, and fail early on invalid input paths to improve diagnostics and safety.

### Description
- Replace `printf` with `fprintf(stderr, ...)`, localize file I/O and allocation error messages to Arabic in `src/support/read_file.c`, and add a defensive `NULL`/empty-path check at the start of `read_file` so invalid paths are rejected with a clear error.

### Testing
- Built the project and ran the quick QA: `cmake -B build-linux -DCMAKE_BUILD_TYPE=Release && cmake --build build-linux -j` (succeeded) and `python3 scripts/qa_run.py --mode quick` (all quick tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a3349b388325883a53c18403294c)