### PR TITLE
Harden read_file diagnostics and path validation; update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/), and this
 
 ### Changed
 
+- **File-reading diagnostics hardening**:
+  - `src/support/read_file.c` now validates empty/null paths defensively before file access.
+  - File I/O failures now include Arabic-first diagnostics with the underlying system error reason.
+  - Fatal read-path diagnostics consistently terminate with `EXIT_FAILURE` via `stderr`.
+
 - **QA orchestration**:
   - `scripts/qa_run.py` now runs the module-size guard before `full` and `stress` QA work, and stops early on hard-cap violations.
 - **CI gating**:

--- a/src/support/read_file.c
+++ b/src/support/read_file.c
@@ -6,15 +6,22 @@
 
 #include "support_internal.h"
 
+#include <errno.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
+
+static const char* read_file_safe_path(const char* path)
+{
+    return (path && path[0] != '\0') ? path : "<unknown>";
+}
 
 static void read_file_die(FILE* f, char* buffer, const char* msg)
 {
     if (f) fclose(f);
     free(buffer);
-    printf("%s\n", msg);
-    exit(1);
+    fprintf(stderr, "%s\n", msg);
+    exit(EXIT_FAILURE);
 }
 
 typedef enum
@@ -25,67 +32,83 @@ typedef enum
     READ_FILE_ERR_READ,
 } ReadFilePathError;
 
-static void read_file_die_path(FILE* f, char* buffer, const char* path, ReadFilePathError err)
+static void read_file_die_path(FILE* f, char* buffer, const char* path,
+                               ReadFilePathError err, int sys_errno)
 {
+    const char* safe_path = read_file_safe_path(path);
+    const char* reason = (sys_errno != 0) ? strerror(sys_errno) : "سبب نظام غير متاح";
+
     if (f) fclose(f);
     free(buffer);
+
     switch (err)
     {
         case READ_FILE_ERR_OPEN:
-            printf("Error: Could not open input file '%s'\n", path);
+            fprintf(stderr, "خطأ: تعذّر فتح ملف الإدخال '%s' (%s)\n", safe_path, reason);
             break;
         case READ_FILE_ERR_SEEK:
-            printf("Error: Could not seek input file '%s'\n", path);
+            fprintf(stderr, "خطأ: تعذّر تحريك مؤشر ملف الإدخال '%s' (%s)\n", safe_path, reason);
             break;
         case READ_FILE_ERR_SIZE:
-            printf("Error: Could not read size of input file '%s'\n", path);
+            fprintf(stderr, "خطأ: تعذّر قراءة حجم ملف الإدخال '%s' (%s)\n", safe_path, reason);
             break;
         case READ_FILE_ERR_READ:
-            printf("Error: Could not read input file '%s'\n", path);
+            fprintf(stderr, "خطأ: تعذّرت قراءة ملف الإدخال '%s' (%s)\n", safe_path, reason);
             break;
         default:
-            printf("Error: Could not read input file '%s'\n", path);
+            fprintf(stderr, "خطأ: تعذّرت قراءة ملف الإدخال '%s' (%s)\n", safe_path, reason);
             break;
     }
-    exit(1);
+
+    exit(EXIT_FAILURE);
 }
 
-char *read_file(const char *path)
+char* read_file(const char* path)
 {
-    FILE *f = fopen(path, "rb");
+    if (!path || path[0] == '\0')
+    {
+        read_file_die(NULL, NULL, "خطأ: مسار ملف الإدخال غير صالح");
+    }
+
+    errno = 0;
+    FILE* f = fopen(path, "rb");
     if (!f)
     {
-        read_file_die_path(NULL, NULL, path, READ_FILE_ERR_OPEN);
+        read_file_die_path(NULL, NULL, path, READ_FILE_ERR_OPEN, errno);
     }
 
+    errno = 0;
     if (fseek(f, 0, SEEK_END) != 0)
     {
-        read_file_die_path(f, NULL, path, READ_FILE_ERR_SEEK);
+        read_file_die_path(f, NULL, path, READ_FILE_ERR_SEEK, errno);
     }
 
+    errno = 0;
     long length = ftell(f);
     if (length < 0)
     {
-        read_file_die_path(f, NULL, path, READ_FILE_ERR_SIZE);
+        read_file_die_path(f, NULL, path, READ_FILE_ERR_SIZE, errno);
     }
 
+    errno = 0;
     if (fseek(f, 0, SEEK_SET) != 0)
     {
-        read_file_die_path(f, NULL, path, READ_FILE_ERR_SEEK);
+        read_file_die_path(f, NULL, path, READ_FILE_ERR_SEEK, errno);
     }
 
-    char *buffer = (char *)malloc((size_t)length + 1);
+    char* buffer = (char*)malloc((size_t)length + 1u);
     if (!buffer)
     {
-        read_file_die(f, NULL, "Error: Memory allocation failed");
+        read_file_die(f, NULL, "خطأ: فشل حجز الذاكرة لقراءة الملف");
     }
 
+    errno = 0;
     size_t got = fread(buffer, 1, (size_t)length, f);
     if (got != (size_t)length)
     {
         if (ferror(f))
         {
-            read_file_die_path(f, buffer, path, READ_FILE_ERR_READ);
+            read_file_die_path(f, buffer, path, READ_FILE_ERR_READ, errno);
         }
         length = (long)got;
     }


### PR DESCRIPTION
### Motivation

- Improve robustness of file reading by validating input paths before use to avoid undefined behavior on empty or null paths.
- Provide clearer, localized diagnostics that include underlying system error reasons to aid debugging.
- Ensure consistent process termination semantics on fatal read errors.

### Description

- Added defensive path validation via `read_file_safe_path` and an early check in `read_file` to detect null or empty paths.
- Propagated `errno` into a new `read_file_die_path` signature and included `strerror(errno)` in Arabic-first diagnostic messages.
- Switched diagnostic output to `stderr`, unified fatal exits to use `exit(EXIT_FAILURE)`, and added `errno` and `string.h` includes.
- Minor memory and style tweaks including a cast to `char*` on `malloc` and using `1u` for the allocation size; and updated `CHANGELOG.md` to document the change.

### Testing

- Built the project with the usual CMake build to verify compilation succeeded. 
- Ran the repository's automated test suite via `ctest` to ensure no regressions in existing tests, and all tests passed. 
- Executed the QA script `scripts/qa_run.py full` to validate guard integration and diagnostic behavior, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1a3349b388325883a53c18403294c)